### PR TITLE
DCA-238 index snapshot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ At the moment, Jira DC support is in beta. Confluence DC and Bitbucket DC suppor
 
 ## Supported versions
 * Supported Jira versions: 
-    * Latest platform release: 8.0.3
-    * Previous enterprise release: 7.13.6
-    * Latest enterprise release: 8.5.0
+    * The latest Platform Release: 8.0.3
+    * The following Jira [Enterprise Releases](https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html): 7.13.6 and 8.5.0
     
 * Supported Confluence versions:
-    * Latest enterprise release: 6.13.8
+    * The latest Confluence [Enterprise Release](https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html): 6.13.8
 
 ## Installation and set up
 

--- a/app/util/confluence/index-snapshot.sh
+++ b/app/util/confluence/index-snapshot.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Wait until index snapshot for Confluence DC is generated
+
+SNAPSHOT="/media/atl/confluence/shared-home/index-snapshots/IndexSnapshot_main_index_*zip"
+
+TEMP_DIR="/var/atlassian/application-data/confluence/temp"
+TEMP_ZIP="/var/atlassian/application-data/confluence/index/*main_index*zip"
+
+
+TIMEOUT=3600    # 1 hour
+COUNTER=0
+SLEEP_TIME=20
+ATTEMPTS=$((TIMEOUT / SLEEP_TIME))
+FAIL_FAST_COUNTER=0
+FAIL_FAST_ATTEMPTS=15
+
+
+while [ ${COUNTER} -lt ${ATTEMPTS} ];do
+    if sudo su -c "test -f ${SNAPSHOT}"; then
+        echo # New line
+        echo "Snapshot was created successfully."
+        break
+    fi
+
+    if [ ${FAIL_FAST_COUNTER} -eq ${FAIL_FAST_ATTEMPTS} ]; then
+        echo # move to a new line
+        echo "Snapshot generation did not started."
+        echo "Try to create a new Confluence page in UI and run 'General configuration' > 'Scheduled Jobs' > 'Clean Journal Entries' job again."
+        exit 1
+    fi
+
+    if sudo su -c "test -d ${TEMP_DIR}"; then
+        TEMP_DIR_SIZE=`sudo su -c "du -s ${TEMP_DIR}" | cut -f1`
+        if [[ ${TEMP_DIR_SIZE} -gt 0 ]]; then
+            echo "Temp dir found. Current temp dir size: ${TEMP_DIR_SIZE}"
+        else
+            let FAIL_FAST_COUNTER=$FAIL_FAST_COUNTER+1
+        fi
+    fi
+
+    if sudo su -c "test -f ${TEMP_ZIP}"; then
+        TEMP_ZIP_SIZE=`sudo su -c "du -s ${TEMP_ZIP}" | cut -f1`
+        echo "Temp ZIP file found. Current temp ZIP file size: ${TEMP_ZIP_SIZE}"
+    fi
+
+    echo "Waiting for Snapshot generation, attempt ${COUNTER}/${ATTEMPTS} at waiting ${SLEEP_TIME} seconds."
+    echo # New line
+    echo # New line
+    sleep ${SLEEP_TIME}
+    let COUNTER=$COUNTER+1
+done
+
+if [ ${COUNTER} -eq ${ATTEMPTS} ]; then
+    echo # move to a new line
+    echo "Snapshot generation fails."
+    echo "Try to create a new Confluence page in UI and run 'General configuration' > 'Scheduled Jobs' > 'Clean Journal Entries' job again."
+    exit 1
+fi

--- a/app/util/confluence/index-sync.sh
+++ b/app/util/confluence/index-sync.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Wait until index sync is finished on a new Confluence DC node
+
 SEARCH_LOG="/var/atlassian/application-data/confluence/logs/atlassian-confluence.log"
 TIMEOUT=1200
 

--- a/docs/dc-apps-performance-toolkit-user-guide-confluence.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-confluence.md
@@ -61,7 +61,7 @@ The Data Center App Performance Toolkit officially supports:
 | Cluster node instance type | [c5.4xlarge](https://aws.amazon.com/ec2/instance-types/c5/) |
 | Maximum number of cluster nodes | 1 |
 | Minimum number of cluster nodes | 1 |
-| Cluster node instance volume size | 100 |
+| Cluster node instance volume size | 200 |
 
 We recommend [c5.4xlarge](https://aws.amazon.com/ec2/instance-types/c5/) to strike the balance between cost and hardware we see in the field for our enterprise customers.
 
@@ -76,7 +76,7 @@ The Data Center App Performance Toolkit framework is also set up for concurrency
 | Master (admin) password | Password1! |
 | Enable RDS Multi-AZ deployment | true |
 | Application user database password | Password1! |
-| Database storage | 100 |
+| Database storage | 200 |
 
 {{% note %}}
 The **Master (admin) password** will be used later when restoring the SQL database dataset. If password value is not set to default, you'll need to change `DB_PASS` value manually in the restore database dump script (later in [Preloading your Confluence deployment with an enterprise-scale dataset](#preloading)).
@@ -98,7 +98,7 @@ The **Master (admin) password** will be used later when restoring the SQL databa
 | --------- | ----------------- |
 | Make instance internet facing | true |
 | Permitted IP range | 0.0.0.0/0 _(for public access) or your own trusted IP range_ |
-|Key Name | _The EC2 Key Pair to allow SSH access. See [Amazon EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) for more info._ |
+| Key Name | _The EC2 Key Pair to allow SSH access. See [Amazon EC2 Key Pairs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) for more info._ |
 
 ### Running the setup wizard
 

--- a/docs/dc-apps-performance-toolkit-user-guide-confluence.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-confluence.md
@@ -139,8 +139,8 @@ Data dimensions and values for an enterprise-scale dataset are listed and descri
 | Pages | ~900 000 |
 | Blogposts | ~100 000 |
 | Attachments | ~2 300 000 |
-| Comments | ~4 000 000 |
-| Spaces  | ~5 500 |
+| Comments | ~6 000 000 |
+| Spaces  | ~5 000 |
 | Users | ~5 000 |
 
 {{% note %}}
@@ -253,7 +253,7 @@ Do not close or interrupt the session. It will take some time to upload attachme
 ### <a id="reindexing"></a> Re-indexing Confluence Data Center (~2-4 hours)
 
 {{% note %}}
-Before re-index, go to **![cog icon](/platform/marketplace/images/cog.png) &gt; General configuration &gt; General configuration**, click **Edit** for **Site Configuration** and set **Base ULR** to **LoadBalancerURL** value.
+Before re-index, go to **![cog icon](/platform/marketplace/images/cog.png) &gt; General configuration &gt; General configuration**, click **Edit** for **Site Configuration** and set **Base URL** to **LoadBalancerURL** value.
 {{% /note %}}
 
 For more information, go to [Re-indexing Confluence](https://confluence.atlassian.com/doc/content-index-administration-148844.html).
@@ -264,6 +264,32 @@ For more information, go to [Re-indexing Confluence](https://confluence.atlassia
 
 Confluence will be unavailable for some time during the re-indexing process.
 
+### <a id="index-snapshot"></a> Create Index Snapshot (~30 min)
+
+For more information, go to [Administer your Data Center search index](https://confluence.atlassian.com/doc/administer-your-data-center-search-index-879956107.html).
+
+1. Log in as a user with the **Confluence System Administrators** [global permission](https://confluence.atlassian.com/doc/global-permissions-overview-138709.html).
+1. Create any new page with a random content (without a new page index snapshot job will not be triggered).
+1. Go to **![cog icon](/platform/marketplace/images/cog.png) &gt; General Configuration &gt; Scheduled Jobs**.
+1. Find **Clean Journal Entries** job and click **Run**.
+1. Make sure that Confluence index snapshot was created. To do that, use SSH to connect to the Confluence node via Bastion (where `NODE_IP` is the IP of the node):
+
+    ```bash
+    ssh-add path_to_your_private_key_pem
+    export BASTION_IP=bastion_instance_public_ip
+    export NODE_IP=node_private_ip
+    ssh -o "proxycommand ssh -W %h:%p ec2-user@$BASTION_IP" ec2-user@${NODE_IP}
+    ```
+1. Download the [index-snapshot.sh](https://raw.githubusercontent.com/atlassian/dc-app-performance-toolkit/master/app/util/confluence/index-snapshot.sh) file. Then, make it executable and run it:
+
+    ```bash
+    wget https://raw.githubusercontent.com/atlassian/dc-app-performance-toolkit/master/app/util/confluence/index-snapshot.sh && chmod +x index-snapshot.sh
+    ./index-snapshot.sh | tee -a index-snapshot.log
+    ```
+    Index snapshot creation time is about 20-30 minutes. When index snapshot is successfully created, the following will be displayed in console output:
+    ```bash
+    Snapshot was created successfully.
+    ```
 
 ## Testing scenarios
 

--- a/docs/dc-apps-performance-toolkit-user-guide-jira.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-jira.md
@@ -52,8 +52,7 @@ All important parameters are listed and described in this section. For all other
 The Data Center App Performance Toolkit officially supports:
 
 - The latest Jira Platform Release version: 8.0.3
-- The latest Jira [Enterprise Release](https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html): 7.13.6
-- The latest Jira Enterprise Release version: 8.5.0
+- The following Jira [Enterprise Releases](https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html): 7.13.6 and 8.5.0
 
 **Cluster nodes**
 
@@ -305,7 +304,7 @@ For more information, go to [Re-indexing Jira](https://confluence.atlassian.com/
 Jira will be unavailable for some time during the re-indexing process. When finished, the **Acknowledge** button will be available on the re-indexing page.
 
 {{% note %}}
-Go to **![cog icon](/platform/marketplace/images/cog.png) &gt; System &gt; General configuration**, click **Edit Settings** and set **Base ULR** to **LoadBalancerURL** value.
+Go to **![cog icon](/platform/marketplace/images/cog.png) &gt; System &gt; General configuration**, click **Edit Settings** and set **Base URL** to **LoadBalancerURL** value.
 {{% /note %}}
 
 ## Testing scenarios


### PR DESCRIPTION
A script that waits until index snapshot is generated.

WARNING:
User Guide is not updated yet with how to use this script. Work in progress.