### PR TITLE
Revert "DCA-278:Bump bzt version to 1.14.0 (#73)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 matplotlib==3.1.1
 pandas==0.25.0
 importlib-metadata==0.20
-bzt==1.14.0
+bzt==1.13.9


### PR DESCRIPTION
This reverts commit 54e9e34e4f4ff05d3e3303ab5893a3cdf7dadcf6.