### PR TITLE
Reduce untar log

### DIFF
--- a/app/util/confluence/upload_attachments.sh
+++ b/app/util/confluence/upload_attachments.sh
@@ -85,7 +85,7 @@ sudo su confluence -c "time wget --progress=dot:giga ${ATTACHMENTS_TAR_URL}"
 
 echo "Step3: Untar attachments to tmp folder"
 sudo su -c "rm -rf ${ATTACHMENTS_DIR}"
-sudo su confluence -c "time tar -xzvf ${ATTACHMENTS_TAR}"
+sudo su confluence -c "time tar -xzf ${ATTACHMENTS_TAR} --checkpoint=.10000"
 if [[ $? -ne 0 ]]; then
   echo "Untar failed!"
   exit 1

--- a/app/util/jira/upload_attachments.sh
+++ b/app/util/jira/upload_attachments.sh
@@ -85,7 +85,7 @@ sudo su jira -c "time wget --progress=dot:giga ${ATTACHMENTS_TAR_URL}"
 
 echo "Step3: Untar attachments to tmp folder"
 sudo su -c "rm -rf ${ATTACHMENTS_DIR}"
-sudo su jira -c "tar -xzvf ${ATTACHMENTS_TAR}"
+sudo su jira -c "tar -xzf ${ATTACHMENTS_TAR} --checkpoint=.10000"
 if [[ $? -ne 0 ]]; then
   echo "Untar failed!"
   exit 1


### PR DESCRIPTION
Instead of 2 000 000 lines in a log we will have 200 dots.