### PR TITLE
Remove w3c timings

### DIFF
--- a/app/selenium_ui/conftest.py
+++ b/app/selenium_ui/conftest.py
@@ -39,13 +39,10 @@ def __get_current_results_dir():
 current_results_dir = __get_current_results_dir()
 selenium_results_file = Path(current_results_dir + '/selenium.jtl')
 selenium_error_file = Path(current_results_dir + '/selenium.err')
-w3c_timings_file = Path(current_results_dir + '/w3c_timings.txt')
 
 if not selenium_results_file.exists():
     with open(selenium_results_file, "w") as file:
         file.write(JTL_HEADER)
-    with open(w3c_timings_file, 'w'):
-        pass
 
 
 def datetime_now(prefix):
@@ -74,11 +71,6 @@ def print_timing(func):
             file.write(f"{timestamp},{timing},{interaction},,{error_msg},,{success},0,0,0,0,,0\n")
 
         print(f"{timestamp},{timing},{interaction},{error_msg},{success}")
-
-        w3c_timing = json.dumps(webdriver.execute_script("return window.performance.getEntries()"))
-        with open(w3c_timings_file, "a+") as file:
-            file.write(f"{{\"timestamp\": {timestamp}, \"timing\": {timing}, \"interation\": \"{interaction}\", "
-                       f"\"error\": \"{error_msg}\", \"success\": \"{success}\", \"w3c_timing\": {w3c_timing}}}\n")
 
         if not success:
             raise Exception(error_msg, full_exception)

--- a/docs/confluence/README.md
+++ b/docs/confluence/README.md
@@ -36,7 +36,6 @@ Results are located in the `resutls/confluence/YY-MM-DD-hh-mm-ss` directory:
 * `kpi.jtl` - JMeter raw data
 * `pytest.out` - detailed log of Selenium execution, including stacktraces of Selenium fails
 * `selenium.jtl` - Selenium raw data
-* `w3c_timings.txt` - w3c browser timings
 * `results.csv` - consolidated results of execution
 
 

--- a/docs/jira/README.md
+++ b/docs/jira/README.md
@@ -36,7 +36,6 @@ Results are located in the `resutls/jira/YY-MM-DD-hh-mm-ss` directory:
 * `kpi.jtl` - JMeter raw data
 * `pytest.out` - detailed log of Selenium execution, including stacktraces of Selenium fails
 * `selenium.jtl` - Selenium raw data
-* `w3c_timings.txt` - w3c browser timings
 * `results.csv` - consolidated results of execution
 
 


### PR DESCRIPTION
@jkim2-atlassian couple of vendors are complaining about "InvalidSessionIdException" allover Selenium actions. It is very difficult to reproduce this issue locally, but I was able to see a couple of those failures on my local Mac and on local Docker. I was not able to understand why this had happened, but it looks like some chromedriver/Chrome versions combination flaky issue. And the problem is in this get_w3c_timing method. As we are not using these stats anyway, I propose to remove this code to reduce customers' flakiness rate. Any thoughts? 