### PR TITLE
Jira escape project keys

### DIFF
--- a/app/jira.yml
+++ b/app/jira.yml
@@ -4,7 +4,7 @@ settings:
   aggregator: consolidator
   verbose: false
   env:
-    application_hostname: jira-loadb-1m6r3ectyb8s-958098497.us-east-2.elb.amazonaws.com #test_jira_instance.atlassian.com   # Jira DC hostname without protocol and port e.g. test-jira.atlassian.com or localhost
+    application_hostname: test_jira_instance.atlassian.com   # Jira DC hostname without protocol and port e.g. test-jira.atlassian.com or localhost
     application_protocol: http      # http or https
     application_port: 80            # 80, 443, 8080, 2990, etc
     application_postfix:            # e.g. /jira in case of url like http://localhost:2990/jira

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -4,7 +4,7 @@ settings:
   aggregator: consolidator
   verbose: false
   env:
-    application_hostname: test_jira_instance.atlassian.com   # Jira DC hostname without protocol and port e.g. test-jira.atlassian.com or localhost
+    application_hostname: jira-loadb-1m6r3ectyb8s-958098497.us-east-2.elb.amazonaws.com #test_jira_instance.atlassian.com   # Jira DC hostname without protocol and port e.g. test-jira.atlassian.com or localhost
     application_protocol: http      # http or https
     application_port: 80            # 80, 443, 8080, 2990, etc
     application_postfix:            # e.g. /jira in case of url like http://localhost:2990/jira

--- a/app/util/data_preparation/confluence/prepare-data.py
+++ b/app/util/data_preparation/confluence/prepare-data.py
@@ -51,7 +51,7 @@ def __get_pages(confluence_api, count):
                       ' and title !~ Selenium'    # filter out pages created by Selenium
                       ' and title !~ Home')       # filter out space Home pages
     if not pages:
-        raise SystemExit(f"There is no Pages in Confluence")
+        raise SystemExit(f"There are no Pages in Confluence")
 
     return pages
 
@@ -61,7 +61,7 @@ def __get_blogs(confluence_api, count):
         0, count, cql='type=blogpost'
                       ' and title !~ Performance')
     if not blogs:
-        raise SystemExit(f"There is no Blog posts in Confluence")
+        raise SystemExit(f"There are no Blog posts in Confluence")
 
     return blogs
 
@@ -73,13 +73,13 @@ def __write_to_file(file_path, items):
 
 
 def write_test_data_to_files(dataset):
-    pages = [f"{page['id']},{page['space']['key']}" for page in dataset['pages']]
+    pages = [f"{page['id']},{page['space']['key']}" for page in dataset[PAGES]]
     __write_to_file(CONFLUENCE_PAGES, pages)
 
-    blogs = [f"{blog['id']},{blog['space']['key']}" for blog in dataset['blogs']]
+    blogs = [f"{blog['id']},{blog['space']['key']}" for blog in dataset[BLOGS]]
     __write_to_file(CONFLUENCE_BLOGS, blogs)
 
-    users = [f"{user['user']['username']},{DEFAULT_USER_PASSWORD}" for user in dataset['users']]
+    users = [f"{user['user']['username']},{DEFAULT_USER_PASSWORD}" for user in dataset[USERS]]
     __write_to_file(CONFLUENCE_USERS, users)
 
 

--- a/app/util/data_preparation/jira/prepare-data.py
+++ b/app/util/data_preparation/jira/prepare-data.py
@@ -90,11 +90,12 @@ def __create_data_set(jira_api):
 
 
 def __get_issues(jira_api, software_project_keys):
+    jql_projects_str = ','.join(f'"{prj}"' for prj in software_project_keys)
     issues = jira_api.issues_search(
-        jql=f"project in ({','.join(software_project_keys)}) AND status != Closed order by key", max_results=8000
+        jql=f"project in ({jql_projects_str}) AND status != Closed order by key", max_results=8000
     )
     if not issues:
-        raise SystemExit("There is no issues in Jira")
+        raise SystemExit("There are no issues in Jira")
 
     return issues
 
@@ -102,7 +103,7 @@ def __get_issues(jira_api, software_project_keys):
 def __get_boards(jira_api, board_type):
     boards = jira_api.get_boards(board_type=board_type, max_results=250)
     if not boards:
-        raise SystemExit(f"There is no {board_type} board in Jira")
+        raise SystemExit(f"There are no {board_type} boards in Jira")
 
     return boards
 
@@ -111,7 +112,7 @@ def __get_users(jira_api):
     perf_users = jira_api.get_users(username=DEFAULT_USER_PREFIX, max_results=performance_users_count)
     users = generate_perf_users(api=jira_api, cur_perf_user=perf_users)
     if not users:
-        raise SystemExit("There is no users in Jira")
+        raise SystemExit("There are no users in Jira")
 
     return users
 
@@ -120,7 +121,7 @@ def __get_software_project_keys(jira_api, max_projects_count):
     all_projects = jira_api.get_all_projects()
     software_project_keys = [project['key'] for project in all_projects if 'software' == project.get('projectTypeKey')]
     if not software_project_keys:
-        raise SystemExit("There is no software project in Jira")
+        raise SystemExit("There are no software projects in Jira")
     # Limit number of projects to avoid "Request header is too large" for further requests.
     return software_project_keys[:max_projects_count]
 


### PR DESCRIPTION
Edge case found by the vendor: issues search fails if project key is the same as jql reserved word, e.g. `INT`.
Added project keys escaping with double quotes in jql query.