### PR TITLE
DCA-319: Fix "Add ssh key on Bitbucket" on Windows

### DIFF
--- a/app/jmeter/bitbucket.jmx
+++ b/app/jmeter/bitbucket.jmx
@@ -210,7 +210,7 @@ import org.apache.commons.io.FileUtils;
      File privateKey = new File(gitTmpWorkspace + &quot;/bitbucket_ssh/id_rsa&quot;);
      FileUtils.copyURLToFile(new URL(bitbucketSshKeyUrl), privateKey);
  	FileUtils.copyURLToFile(new URL(bitbucketSshKeyUrl + &quot;.pub&quot;), new File(gitTmpWorkspace + &quot;/bitbucket_ssh/id_rsa.pub&quot;));
- 	String privateSshKeyLocation = gitTmpWorkspace + &quot;/bitbucket_ssh/id_rsa&quot;;
+ 	String privateSshKeyLocation = (gitTmpWorkspace + &quot;/bitbucket_ssh/id_rsa&quot;).replace(&quot;\\&quot;, &quot;/&quot;);
  	props.put(&quot;PRIVATE_SSH_KEY_LOCATION&quot;, privateSshKeyLocation);
      log.info(&quot;SSH keys are stored in &quot; + privateSshKeyLocation);
      props.put(&quot;GIT_SSH_COMMAND&quot;, &quot;ssh -i &quot; + privateSshKeyLocation + &quot; -o \&quot;StrictHostKeyChecking=no\&quot;&quot;);


### PR DESCRIPTION
https://bulldog.internal.atlassian.com/browse/DCA-319?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D