### PR TITLE
DCA-350 skip whole tests if login failed

### DIFF
--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1 r1853635">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.2.1">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -55,6 +55,7 @@
       <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
         <collectionProp name="CookieManager.cookies"/>
         <boolProp name="CookieManager.clearEachIteration">true</boolProp>
+        <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
       </CookieManager>
       <hashTree/>
       <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
@@ -115,6 +116,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration">3600</stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
@@ -395,7 +397,7 @@
               <stringProp name="RegexExtractor.match_number">1</stringProp>
             </RegexExtractor>
             <hashTree/>
-            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="false">
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
               <collectionProp name="Asserion.test_strings">
                 <stringProp name="2081854856">quick-search</stringProp>
                 <stringProp name="2004794418">Log Out</stringProp>
@@ -405,12 +407,6 @@
               <boolProp name="Assertion.assume_success">false</boolProp>
               <intProp name="Assertion.test_type">16</intProp>
             </ResponseAssertion>
-            <hashTree/>
-            <ResultAction guiclass="ResultActionGui" testclass="ResultAction" testname="Result Status Action Handler (Stop thread on Failure)" enabled="true">
-              <stringProp name="TestPlan.comments">Adding this sampler after the login operation to stop and start next thread if fails.
-</stringProp>
-              <intProp name="OnError.action">1</intProp>
-            </ResultAction>
             <hashTree/>
           </hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="010 /rest/webResources/1.0/resources" enabled="true">
@@ -774,6 +770,20 @@
             </HeaderManager>
             <hashTree/>
           </hashTree>
+        </hashTree>
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="login checker" enabled="true">
+          <stringProp name="IfController.condition">${__jexl3(!${JMeterThread.last_sample_ok},)}</stringProp>
+          <boolProp name="IfController.evaluateAll">false</boolProp>
+          <boolProp name="IfController.useExpression">true</boolProp>
+          <stringProp name="TestPlan.comments">Check if login action is success</stringProp>
+        </IfController>
+        <hashTree>
+          <TestAction guiclass="TestActionGui" testclass="TestAction" testname="break loop if login unsuccessful" enabled="true">
+            <intProp name="ActionProcessor.action">5</intProp>
+            <intProp name="ActionProcessor.target">0</intProp>
+            <stringProp name="ActionProcessor.duration">0</stringProp>
+          </TestAction>
+          <hashTree/>
         </hashTree>
         <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="actions per login" enabled="true">
           <boolProp name="LoopController.continue_forever">true</boolProp>
@@ -2902,7 +2912,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -2971,7 +2980,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3024,7 +3032,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3077,7 +3084,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3130,7 +3136,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3183,7 +3188,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3240,7 +3244,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3325,7 +3328,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3395,7 +3397,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3456,7 +3457,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3541,7 +3541,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>
@@ -3633,7 +3632,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3683,7 +3681,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3725,7 +3722,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>
@@ -3778,7 +3774,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3831,7 +3826,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3881,7 +3875,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -3932,7 +3925,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4014,7 +4006,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4073,7 +4064,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -4126,7 +4116,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/plain, */*; q=0.01</stringProp>
@@ -4207,7 +4196,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4270,7 +4258,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>
@@ -4333,7 +4320,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4386,7 +4372,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4428,7 +4413,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>
@@ -4479,7 +4463,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4536,7 +4519,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4589,7 +4571,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4646,7 +4627,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -4703,7 +4683,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4741,7 +4720,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -4787,7 +4765,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4844,7 +4821,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -4929,7 +4905,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -4982,7 +4957,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5035,7 +5009,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5124,7 +5097,6 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5223,7 +5195,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>
@@ -5315,7 +5286,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5368,7 +5338,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5421,7 +5390,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5463,7 +5431,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5513,7 +5480,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5563,7 +5529,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -5613,7 +5578,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5663,7 +5627,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5716,7 +5679,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5798,7 +5760,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5892,7 +5853,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -5954,7 +5914,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>
@@ -6068,7 +6027,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6114,7 +6072,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6167,7 +6124,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6228,7 +6184,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6285,7 +6240,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6342,7 +6296,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6399,7 +6352,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6456,7 +6408,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -6506,7 +6457,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6559,7 +6509,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6612,7 +6561,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6697,7 +6645,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -6750,7 +6697,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6803,7 +6749,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6856,7 +6801,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -6912,7 +6856,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>
@@ -7052,7 +6995,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -7134,7 +7076,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -7191,7 +7132,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -7241,7 +7181,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -7323,7 +7262,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -7373,7 +7311,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -7423,7 +7360,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -7505,7 +7441,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -7783,7 +7718,6 @@ vars.put(&quot;p_page_version&quot;, page_version.toString());</stringProp>
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>
@@ -7880,7 +7814,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -7955,7 +7888,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8001,7 +7933,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8054,7 +7985,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8115,7 +8045,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8172,7 +8101,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8229,7 +8157,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -8286,7 +8213,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8371,7 +8297,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">*/*</stringProp>
@@ -8428,7 +8353,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8478,7 +8402,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8531,7 +8454,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8584,7 +8506,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8637,7 +8558,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8690,7 +8610,6 @@ if (totalAncestorID &gt; 0)
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8797,7 +8716,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">application/json, text/javascript, */*; q=0.01</stringProp>
@@ -8905,7 +8823,6 @@ vars.put(&quot;extend_action&quot;, extend_action);
                       <stringProp name="Header.name">Accept-Encoding</stringProp>
                       <stringProp name="Header.value">gzip, deflate</stringProp>
                     </elementProp>
-                    
                     <elementProp name="Accept" elementType="Header">
                       <stringProp name="Header.name">Accept</stringProp>
                       <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</stringProp>

--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -329,7 +329,7 @@
             <stringProp name="HTTPSampler.port"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">${application.postfix}/index.action</stringProp>
+            <stringProp name="HTTPSampler.path">${application.postfix}/</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -399,7 +399,6 @@
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
               <collectionProp name="Asserion.test_strings">
-                <stringProp name="2081854856">quick-search</stringProp>
                 <stringProp name="2004794418">Log Out</stringProp>
               </collectionProp>
               <stringProp name="Assertion.custom_message"></stringProp>

--- a/app/jmeter/jira.jmx
+++ b/app/jmeter/jira.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1 r1853635">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.2.1">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -56,6 +56,7 @@
       <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager" enabled="true">
         <collectionProp name="CookieManager.cookies"/>
         <boolProp name="CookieManager.clearEachIteration">true</boolProp>
+        <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
       </CookieManager>
       <hashTree/>
       <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
@@ -150,6 +151,7 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </SetupThreadGroup>
       <hashTree>
         <TestAction guiclass="TestActionGui" testclass="TestAction" testname="page count" enabled="true">
@@ -186,6 +188,7 @@ props.put(&quot;project_pages&quot;, String.valueOf(pages));</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration">0</stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="users" enabled="true">
@@ -1086,6 +1089,20 @@ JMeterUtils.setProperty(&quot;c_AtlToken&quot; + user_counter, atl_token)
             </HeaderManager>
             <hashTree/>
           </hashTree>
+        </hashTree>
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="login checker" enabled="true">
+          <stringProp name="IfController.condition">${__jexl3(!${JMeterThread.last_sample_ok},)}</stringProp>
+          <boolProp name="IfController.evaluateAll">false</boolProp>
+          <boolProp name="IfController.useExpression">true</boolProp>
+          <stringProp name="TestPlan.comments">Check if login action is success</stringProp>
+        </IfController>
+        <hashTree>
+          <TestAction guiclass="TestActionGui" testclass="TestAction" testname="break loop if login unsuccessful" enabled="true">
+            <intProp name="ActionProcessor.action">5</intProp>
+            <intProp name="ActionProcessor.target">0</intProp>
+            <stringProp name="ActionProcessor.duration">0</stringProp>
+          </TestAction>
+          <hashTree/>
         </hashTree>
         <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="actions per login" enabled="true">
           <boolProp name="LoopController.continue_forever">true</boolProp>

--- a/app/selenium_ui/conftest.py
+++ b/app/selenium_ui/conftest.py
@@ -26,6 +26,7 @@ JTL_HEADER = "timeStamp,elapsed,label,responseCode,responseMessage,threadName,su
              "Latency,Hostname,Connect\n"
 LOGIN_ACTION_NAME = 'login'
 
+
 def __get_current_results_dir():
     if 'TAURUS_ARTIFACTS_DIR' in os.environ:
         return os.environ.get('TAURUS_ARTIFACTS_DIR')

--- a/app/selenium_ui/conftest.py
+++ b/app/selenium_ui/conftest.py
@@ -107,7 +107,7 @@ def webdriver():
         chrome_options.add_argument("--window-size={},{}".format(SCREEN_WIDTH, SCREEN_HEIGHT))
         chrome_options.add_argument("--no-sandbox")
         chrome_options.add_argument("--disable-infobars")
-        driver = Chrome(executable_path='/Users/smoro/.bzt/selenium-taurus/tools/chromedriver/81.0.4044.69/chromedriver', options=chrome_options)
+        driver = Chrome(options=chrome_options)
         return driver
 
 

--- a/app/selenium_ui/conftest.py
+++ b/app/selenium_ui/conftest.py
@@ -58,13 +58,11 @@ def print_timing(interaction=None):
     def deco_wrapper(func):
         @functools.wraps(func)
         def wrapper():
-            global fail_login
+            global login_failed
             if LOGIN_ACTION_NAME in interaction:
-                fail_login = False
-            if fail_login:
+                login_failed = False
+            if login_failed:
                 pytest.skip(f"login is failed")
-            fail_login = False
-            f_interaction = interaction
             start = time.time()
             error_msg = 'Success'
             full_exception = ''
@@ -75,19 +73,19 @@ def print_timing(interaction=None):
                 success = False
                 # https://docs.python.org/2/library/sys.html#sys.exc_info
                 exc_type, full_exception = sys.exc_info()[:2]
-                error_msg = f"Failed measure: {f_interaction} - {exc_type.__name__}"
+                error_msg = f"Failed measure: {interaction} - {exc_type.__name__}"
             end = time.time()
             timing = str(int((end - start) * 1000))
 
             with open(selenium_results_file, "a+") as jtl_file:
                 timestamp = round(time.time() * 1000)
-                jtl_file.write(f"{timestamp},{timing},{f_interaction},,{error_msg},,{success},0,0,0,0,,0\n")
+                jtl_file.write(f"{timestamp},{timing},{interaction},,{error_msg},,{success},0,0,0,0,,0\n")
 
-            print(f"{timestamp},{timing},{f_interaction},{error_msg},{success}")
+            print(f"{timestamp},{timing},{interaction},{error_msg},{success}")
 
             if not success:
                 if LOGIN_ACTION_NAME in interaction:
-                    fail_login = True
+                    login_failed = True
                 raise Exception(error_msg, full_exception)
 
         return wrapper
@@ -108,7 +106,7 @@ def webdriver():
         chrome_options.add_argument("--window-size={},{}".format(SCREEN_WIDTH, SCREEN_HEIGHT))
         chrome_options.add_argument("--no-sandbox")
         chrome_options.add_argument("--disable-infobars")
-        driver = Chrome(options=chrome_options)
+        driver = Chrome(executable_path='/Users/smoro/.bzt/selenium-taurus/tools/chromedriver/81.0.4044.69/chromedriver', options=chrome_options)
         return driver
 
 


### PR DESCRIPTION
<img width="1215" alt="Screen Shot 2020-04-22 at 10 14 37 PM" src="https://user-images.githubusercontent.com/17962651/80023794-c32be600-84e6-11ea-897d-0f347203717a.png">
<img width="1215" alt="Screen Shot 2020-04-22 at 10 14 58 PM" src="https://user-images.githubusercontent.com/17962651/80023801-c626d680-84e6-11ea-8f10-a76831f766f1.png">
<img width="1393" alt="Screen Shot 2020-04-22 at 11 01 09 PM" src="https://user-images.githubusercontent.com/17962651/80028041-320c3d80-84ed-11ea-8b7d-56efe1d7835f.png">

Each time login is failed, all next actions will be skipped. 
In the picture above - an example of the current implementation for Confluence. Failed login does not affect other actions.