### PR TITLE
Reduced cache size for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -y update \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \
   && python -m pip install --upgrade pip \
   && python -m pip install --upgrade setuptools \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get clean
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get -y update \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \
   && python -m pip install --upgrade pip \
   && python -m pip install --upgrade setuptools \
-  && apt-get clean
+  && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 RUN rm -rf /root/.bzt/jmeter-taurus/
 


### PR DESCRIPTION
Original image size:
dc-app-performance-toolkit 3.89GB
New image size:
dc-app-performance-toolkit-new 3.83GB

Unfortunately Github doesn't allow to change origin for PR's created from web UI, so I recreated it using regular git. 
Fix of https://github.com/atlassian/dc-app-performance-toolkit/pull/344