### PR TITLE
Update versions of jira in jira guide

### DIFF
--- a/docs/dc-apps-performance-toolkit-user-guide-jira.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-jira.md
@@ -62,7 +62,7 @@ All important parameters are listed and described in this section. For all other
 | Parameter | Recommended value |
 | --------- | ----------------- |
 | Jira Product | Software |
-| Jira Version | The Data Center App Performance Toolkit officially supports `8.0.3` or `7.13.15` ([Long Term Support release](https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html)) or `8.5.6` |
+| Jira Version | The Data Center App Performance Toolkit officially supports `8.0.3` or `7.13.15` ([Long Term Support release](https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html)) or `8.5.8` |
 
 **Cluster nodes**
 
@@ -407,7 +407,7 @@ All important parameters are listed and described in this section. For all other
 | Parameter | Recommended Value |
 | --------- | ----------------- |
 | Jira Product | Software |
-| Jira Version | The Data Center App Performance Toolkit officially supports `8.0.3` or `7.13.15` ([Long Term Support release](https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html)) or `8.5.6` |
+| Jira Version | The Data Center App Performance Toolkit officially supports `8.0.3` or `7.13.15` ([Long Term Support release](https://confluence.atlassian.com/enterprise/atlassian-enterprise-releases-948227420.html)) or `8.5.8` |
 
 **Cluster nodes**
 


### PR DESCRIPTION
`dc-apps-performance-toolkit-user-guide-jira.md` still says that the officially supported LTS is  `8.5.6`, but the `README.md` and `populate-db.sh` say `8.5.8`.