### PR TITLE
Correct misspelling of "Assertion" on jira.jmx

### DIFF
--- a/app/jmeter/bitbucket.jmx
+++ b/app/jmeter/bitbucket.jmx
@@ -346,7 +346,7 @@ else{
           </HTTPSamplerProxy>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="49586">200</stringProp>
               </collectionProp>
               <stringProp name="Assertion.custom_message"></stringProp>
@@ -461,7 +461,7 @@ vars.put(&quot;USER_SSH_KEY&quot;, new File(&apos;${__P(PRIVATE_SSH_KEY_LOCATION
               </HeaderManager>
               <hashTree/>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="49587">201</stringProp>
                   <stringProp name="51517">409</stringProp>
                   <stringProp name="0"></stringProp>

--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -362,7 +362,7 @@
             </RegexExtractor>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="2004794418">Log Out</stringProp>
               </collectionProp>
               <stringProp name="Assertion.custom_message"></stringProp>
@@ -887,7 +887,7 @@
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-931882833">Created by</stringProp>
                     <stringProp name="1459659186">Save for later</stringProp>
                   </collectionProp>
@@ -1313,7 +1313,7 @@ if (totalAncestorID &gt; 0)
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-1022457886">authorDisplayName</stringProp>
                     <stringProp name="2914">[]</stringProp>
                   </collectionProp>
@@ -1749,7 +1749,7 @@ vars.put(&quot;tree_request&quot;, request)</stringProp>
                   </JSR223PreProcessor>
                   <hashTree/>
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                    <collectionProp name="Asserion.test_strings">
+                    <collectionProp name="Assertion.test_strings">
                       <stringProp name="655775236">plugin_pagetree_children_span</stringProp>
                       <stringProp name="655560536">plugin_pagetree_children_list</stringProp>
                     </collectionProp>
@@ -1830,7 +1830,7 @@ vars.put(&quot;tree_request&quot;, request)</stringProp>
                   </JSR223PreProcessor>
                   <hashTree/>
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                    <collectionProp name="Asserion.test_strings">
+                    <collectionProp name="Assertion.test_strings">
                       <stringProp name="655775236">plugin_pagetree_children_span</stringProp>
                       <stringProp name="655560536">plugin_pagetree_children_list</stringProp>
                     </collectionProp>
@@ -1943,7 +1943,7 @@ vars.put(&quot;tree_request&quot;, request)</stringProp>
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="2081854856">quick-search</stringProp>
                     <stringProp name="2004794418">Log Out</stringProp>
                   </collectionProp>
@@ -2410,7 +2410,7 @@ vars.put(&quot;tree_request&quot;, request)</stringProp>
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-931882833">Created by</stringProp>
                     <stringProp name="1459659186">Save for later</stringProp>
                   </collectionProp>
@@ -2835,7 +2835,7 @@ vars.put(&quot;tree_request&quot;, request)</stringProp>
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1912512156">draftId</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -3290,7 +3290,7 @@ vars.put(&quot;tree_request&quot;, request)</stringProp>
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1454469524">{&quot;results&quot;:[</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -3413,7 +3413,7 @@ vars.put(&quot;tree_request&quot;, request)</stringProp>
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-1653015050">Blog post title</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -3951,7 +3951,7 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                 </JSR223PreProcessor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1912512156">draftId</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -4029,7 +4029,7 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1126940025">current</stringProp>
                     <stringProp name="110371416">title</stringProp>
                   </collectionProp>
@@ -4081,7 +4081,7 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-931882833">Created by</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -4997,7 +4997,7 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1790713223">Page Title</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -5628,7 +5628,7 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1912512156">draftId</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -5679,7 +5679,7 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-931882833">Created by</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -6700,7 +6700,7 @@ vars.put(&quot;p_new_file_name&quot;, (new Random().with {(1..9).collect {((&apo
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="2046823756">&lt;title&gt;Edit</stringProp>
                     <stringProp name="1975472560">Update&lt;/button&gt;</stringProp>
                   </collectionProp>
@@ -7270,7 +7270,7 @@ vars.put(&quot;p_page_version&quot;, page_version.toString());</stringProp>
                   </JSR223PreProcessor>
                   <hashTree/>
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                    <collectionProp name="Asserion.test_strings">
+                    <collectionProp name="Assertion.test_strings">
                       <stringProp name="-279447717">&quot;title&quot;:&quot;Test Performance Edit with JMeter ${p_new_file_name}&quot;</stringProp>
                     </collectionProp>
                     <stringProp name="Assertion.custom_message"></stringProp>
@@ -7382,7 +7382,7 @@ vars.put(&quot;p_page_version&quot;, page_version.toString());</stringProp>
                   </JSR223PreProcessor>
                   <hashTree/>
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                    <collectionProp name="Asserion.test_strings">
+                    <collectionProp name="Assertion.test_strings">
                       <stringProp name="-279447717">&quot;title&quot;:&quot;Test Performance Edit with JMeter ${p_new_file_name}&quot;</stringProp>
                     </collectionProp>
                     <stringProp name="Assertion.custom_message"></stringProp>
@@ -7434,7 +7434,7 @@ vars.put(&quot;p_page_version&quot;, page_version.toString());</stringProp>
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="150043680">last-modified</stringProp>
                     <stringProp name="-931882833">Created by</stringProp>
                   </collectionProp>
@@ -8423,7 +8423,7 @@ vars.put(&quot;p_uuid&quot;, UUID.randomUUID().toString());</stringProp>
                 </JSR223PreProcessor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="34364028">reply-comment</stringProp>
                     <stringProp name="248026524">edit-comment</stringProp>
                   </collectionProp>
@@ -8497,7 +8497,7 @@ vars.put(&quot;p_uuid&quot;, UUID.randomUUID().toString());</stringProp>
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-1620699109">Upload file</stringProp>
                     <stringProp name="-1584205177">Attach more files</stringProp>
                     <stringProp name="1271801353">Download All</stringProp>
@@ -8633,7 +8633,7 @@ vars.put(&quot;p_uuid&quot;, UUID.randomUUID().toString());</stringProp>
                   </HeaderManager>
                   <hashTree/>
                   <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                    <collectionProp name="Asserion.test_strings">
+                    <collectionProp name="Assertion.test_strings">
                       <stringProp name="-1620699109">Upload file</stringProp>
                       <stringProp name="-1584205177">Attach more files</stringProp>
                     </collectionProp>
@@ -8883,7 +8883,7 @@ vars.put(&quot;p_uuid&quot;, UUID.randomUUID().toString());</stringProp>
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="assertion after GET request" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-787535121">assertion string</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -8928,7 +8928,7 @@ vars.put(&quot;p_uuid&quot;, UUID.randomUUID().toString());</stringProp>
               </HTTPSamplerProxy>
               <hashTree>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-787535121">assertion string</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>

--- a/app/jmeter/jira.jmx
+++ b/app/jmeter/jira.jmx
@@ -417,7 +417,7 @@ JMeterUtils.setProperty(&quot;c_AtlToken&quot; + user_counter, atl_token)
             </JSR223PostProcessor>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1948182085">title=&quot;loggedInUser&quot; value=&quot;${username}&quot;</stringProp>
               </collectionProp>
               <stringProp name="Assertion.custom_message"></stringProp>
@@ -548,7 +548,7 @@ JMeterUtils.setProperty(&quot;c_AtlToken&quot; + user_counter, atl_token)
             </HeaderManager>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings"/>
+              <collectionProp name="Assertion.test_strings"/>
               <stringProp name="Assertion.custom_message"></stringProp>
               <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
               <boolProp name="Assertion.assume_success">true</boolProp>
@@ -1202,7 +1202,7 @@ JMeterUtils.setProperty(&quot;c_AtlToken&quot; + user_counter, atl_token)
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-1794770517">&quot;id&quot;:&quot;project&quot;,&quot;label&quot;:&quot;Project&quot;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -1389,7 +1389,7 @@ vars.put(&quot;p_request_body&quot;, request_body.toString())
                 </JSR223PreProcessor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-1794770517">&quot;id&quot;:&quot;project&quot;,&quot;label&quot;:&quot;Project&quot;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -2347,7 +2347,7 @@ vars.put(&quot;p_request_body&quot;, p_request_body.trim());
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-1530831458">&lt;meta name=&quot;ajs-issue-key&quot; content=&quot;${issue_key}&quot;&gt;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -2856,7 +2856,7 @@ vars.put(&quot;p_request_body&quot;, p_request_body.trim());
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1182867844">[&quot;project-key&quot;]=&quot;\&quot;${project_key}\&quot;&quot;;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -3632,7 +3632,7 @@ vars.put(&quot;p_request_body&quot;, p_request_body.trim());
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-1948182085">title=&quot;loggedInUser&quot; value=&quot;${username}&quot;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -3937,7 +3937,7 @@ vars.put(&quot;p_request_body&quot;, p_request_body.trim());
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings"/>
+                  <collectionProp name="Assertion.test_strings"/>
                   <stringProp name="Assertion.custom_message"></stringProp>
                   <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
                   <boolProp name="Assertion.assume_success">true</boolProp>
@@ -4553,7 +4553,7 @@ vars.put(&quot;p_request_body&quot;, p_request_body.trim());
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="952779966"> Edit Issue:  [${issue_key}]</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -4969,7 +4969,7 @@ vars.put(&quot;p_request_body&quot;, p_request_body.trim());
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-250224249">[${issue_key}]</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -5498,7 +5498,7 @@ vars.put(&quot;random_string_long&quot;, random_string_long)
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="879966593">Add Comment: ${issue_key}</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -5858,7 +5858,7 @@ vars.put(&quot;p_comment&quot;, comment.toString())
                 </JSR223PreProcessor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-1530831458">&lt;meta name=&quot;ajs-issue-key&quot; content=&quot;${issue_key}&quot;&gt;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -5957,7 +5957,7 @@ vars.put(&quot;random_page&quot;, String.valueOf(random_page));</stringProp>
                 </HeaderManager>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1350597856">WRM._unparsedData[&quot;com.atlassian.jira.project.browse:projects&quot;]=&quot;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -6213,7 +6213,7 @@ vars.put(&quot;random_page&quot;, String.valueOf(random_page));</stringProp>
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-659010545">&quot;{\&quot;currentViewConfig\&quot;:{\&quot;id\&quot;:${kanban_board_id},\&quot;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -7100,7 +7100,7 @@ vars.put(&quot;random_page&quot;, String.valueOf(random_page));</stringProp>
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1102120432">&quot;{\&quot;currentViewConfig\&quot;:{\&quot;id\&quot;:${scrum_board_id},\&quot;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -7994,7 +7994,7 @@ vars.put(&quot;random_page&quot;, String.valueOf(random_page));</stringProp>
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="1102120432">&quot;{\&quot;currentViewConfig\&quot;:{\&quot;id\&quot;:${scrum_board_id},\&quot;</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -9291,7 +9291,7 @@ vars.put(&quot;random_page&quot;, String.valueOf(random_page));</stringProp>
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="assertion after GET request" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="261585815">asserttion string</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -9336,7 +9336,7 @@ vars.put(&quot;random_page&quot;, String.valueOf(random_page));</stringProp>
               </HTTPSamplerProxy>
               <hashTree>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="assertion after POST request" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-787535121">assertion string</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>

--- a/app/jmeter/jsm_agents.jmx
+++ b/app/jmeter/jsm_agents.jmx
@@ -384,7 +384,7 @@ JMeterUtils.setProperty(&quot;c_AtlToken&quot; + user_counter, atl_token)
             </JSR223PostProcessor>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1948182085">title=&quot;loggedInUser&quot; value=&quot;${username}&quot;</stringProp>
               </collectionProp>
               <stringProp name="Assertion.custom_message"></stringProp>
@@ -515,7 +515,7 @@ JMeterUtils.setProperty(&quot;c_AtlToken&quot; + user_counter, atl_token)
             </HeaderManager>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings"/>
+              <collectionProp name="Assertion.test_strings"/>
               <stringProp name="Assertion.custom_message"></stringProp>
               <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
               <boolProp name="Assertion.assume_success">true</boolProp>
@@ -9564,7 +9564,7 @@ vars.put(&quot;g_comment&quot;, comment.toString())
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="assertion after GET request" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="261585815">asserttion string</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -9609,7 +9609,7 @@ vars.put(&quot;g_comment&quot;, comment.toString())
               </HTTPSamplerProxy>
               <hashTree>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="assertion after POST request" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-787535121">assertion string</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>

--- a/app/jmeter/jsm_customers.jmx
+++ b/app/jmeter/jsm_customers.jmx
@@ -2015,7 +2015,7 @@ vars.put(&quot;p_summary&quot;, comment.toString())
                 </RegexExtractor>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="assertion after GET request" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="261585815">asserttion string</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>
@@ -2060,7 +2060,7 @@ vars.put(&quot;p_summary&quot;, comment.toString())
               </HTTPSamplerProxy>
               <hashTree>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="assertion after POST request" enabled="true">
-                  <collectionProp name="Asserion.test_strings">
+                  <collectionProp name="Assertion.test_strings">
                     <stringProp name="-787535121">assertion string</stringProp>
                   </collectionProp>
                   <stringProp name="Assertion.custom_message"></stringProp>


### PR DESCRIPTION
Many occurences of "Asserion" instead of "Assertion". This caused some tests to fail.