### PR TITLE
DCA-1084 adjust percentages of actions for jira, confluence and jsm

### DIFF
--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -21,16 +21,16 @@ settings:
     LANGUAGE: en_US.utf8
     allow_analytics: No            # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     # Action percentage for JMeter and Locust load executors
-    view_page: 54
-    view_dashboard: 6
-    view_blog: 8
-    search_cql: 7
+    view_page: 46
+    view_dashboard: 8
+    view_blog: 10
+    search_cql: 9
     create_blog: 3
-    create_and_edit_page: 6
-    comment_page: 5
-    view_attachment: 3
+    create_and_edit_page: 7
+    comment_page: 6
+    view_attachment: 4
     upload_attachment: 5
-    like_page: 3
+    like_page: 2
     standalone_extension: 0 # By default disabled
     # Custom dataset section.
     custom_dataset_query:           # Write CQL query to add CQL output to the app/datasets/confluence/custom_pages.csv, e.g. "title ~ 'AppPage*'"

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -22,17 +22,17 @@ settings:
     allow_analytics: No            # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     # Action percentage for Jmeter and Locust load executors
     create_issue: 4
-    search_jql: 13
-    view_issue: 43
-    view_project_summary: 4
-    view_dashboard: 12
-    edit_issue: 4
+    search_jql: 11
+    view_issue: 34
+    view_project_summary: 3
+    view_dashboard: 10
+    edit_issue: 5
     add_comment: 2
-    browse_projects: 4
-    view_scrum_board: 3
-    view_kanban_board: 3
+    browse_projects: 9
+    view_scrum_board: 8
+    view_kanban_board: 7
     view_backlog: 6
-    browse_boards: 2
+    browse_boards: 1
     standalone_extension: 0 # By default disabled
     # Custom dataset section.
     custom_dataset_query:          # Write JQL query to add JQL output to the app/datasets/jira/custom-issues.csv, e.g. "summary ~ 'AppIssue*'"

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -24,24 +24,24 @@ settings:
     allow_analytics: No             # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     # Action percentage for Jmeter and Locust load executors
     agent_browse_projects: 10
-    agent_view_request: 25
-    agent_add_comment: 25
-    agent_view_queues_small: 10
-    agent_view_queues_medium: 10
+    agent_view_request: 24
+    agent_add_comment: 26
+    agent_view_queues_small: 11
+    agent_view_queues_medium: 9
     agent_view_report_workload_small: 4
-    agent_view_report_workload_medium: 4
-    agent_view_report_created_vs_resolved_small: 4
-    agent_view_report_created_vs_resolved_medium: 4
-    agent_view_customers: 4
+    agent_view_report_workload_medium: 3
+    agent_view_report_created_vs_resolved_small: 5
+    agent_view_report_created_vs_resolved_medium: 2
+    agent_view_customers: 6
     agent_standalone_extension: 0
 
-    customer_view_portal: 10
+    customer_view_portal: 11
     customer_view_requests: 25
     customer_view_request: 15
-    customer_add_comment: 25
+    customer_add_comment: 24
     customer_share_request_with_customer: 5
-    customer_share_request_with_org: 5
-    customer_create_request: 15
+    customer_share_request_with_org: 4
+    customer_create_request: 16
     customer_standalone_extension: 0
 
     custom_dataset_query: ""        # Write JQL query to add JQL output to the app/datasets/jsm/custom-issues.csv, e.g. "summary ~ 'AppRequests*'"


### PR DESCRIPTION
JMeter runs actions with the same percentages in the same loop. Randomize percentages to make actions distribution better.