### PR TITLE
NONE:Clean JMeter default actions

### DIFF
--- a/app/util/default_test_actions.json
+++ b/app/util/default_test_actions.json
@@ -84,7 +84,6 @@
     "jmeter": [
       "jmeter_login_and_view_dashboard",
       "jmeter_view_page:open_page",
-      "jmeter_view_page:view_page_tree",
       "jmeter_view_blog",
       "jmeter_search_cql:recently_viewed",
       "jmeter_search_cql:search_results",


### PR DESCRIPTION
Remove "jmeter_view_page:view_page_tree" after updating Confluence default requsts