### PR TITLE
Fix taurus dockerfile version to avoid bintray

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # bzt run: docker run --shm-size=4g -v "$PWD:/dc-app-performance-toolkit" atlassian/dcapt jira.yml
 # interactive run: docker run -it --entrypoint="/bin/bash" -v "$PWD:/dc-app-performance-toolkit" atlassian/dcapt
 
-FROM blazemeter/taurus
+FROM blazemeter/taurus:unstable
 
 ENV APT_INSTALL="apt-get -y install --no-install-recommends"
 


### PR DESCRIPTION
Since the old version still uses bintray as the `.deb` source, the build fails.
Using  `unstable` fixes it, since it is already fixed upstream at using https://github.com/Blazemeter/taurus/commit/7d939bb372c996f707be200744bab043c17b0fef#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557