### PR TITLE
[JSM] Fix periodic failures of Selenium test 'selenium_agent_add_comment'

### DIFF
--- a/app/selenium_ui/jsm/pages/agent_pages.py
+++ b/app/selenium_ui/jsm/pages/agent_pages.py
@@ -99,14 +99,18 @@ class ViewCustomerRequest(BasePage):
         if rte_status:
             self.wait_until_available_to_switch(ViewCustomerRequestLocators.comment_text_field_RTE)
             tinymce_field = self.get_element(ViewCustomerRequestLocators.comment_tinymce_field)
+            self.driver.execute_script("arguments[0].scrollIntoView(true);", tinymce_field)
             self.action_chains().send_keys_to_element(tinymce_field, comment_text).perform()
             self.return_to_parent_frame()
         else:
             comment_text_field = self.get_element(ViewCustomerRequestLocators.comment_text_field)
+            self.driver.execute_script("arguments[0].scrollIntoView(true);", comment_text_field)
             self.action_chains().move_to_element(comment_text_field).click()\
                 .send_keys_to_element(comment_text_field, comment_text).perform()
 
-        self.get_element(ViewCustomerRequestLocators.comment_internally_btn).click()
+        comment_button = self.get_element(ViewCustomerRequestLocators.comment_internally_btn)
+        self.driver.execute_script("arguments[0].scrollIntoView(true);", comment_button)
+        comment_button.click()
         self.wait_until_visible(ViewCustomerRequestLocators.comment_collapsed_textarea)
 
 


### PR DESCRIPTION
## Error description

While running the performance tests for JSM with the large dataset, I find ~6% of the repetitions of the 'selenium_agent_add_comment' test failing with the following exception:

```python
Exception: ('Failed measure: selenium_agent_add_comment - Exception', Exception('Failed measure: selenium_agent_add_comment:add comment - MoveTargetOutOfBoundsException', MoveTargetOutOfBoundsException('move target out of bounds\n  (Session info: headless chrome=90.0.4430.85)', None, None)))
```

A screenshot from one of the failing tests are found below:

![test_1_selenium_agent_add_comment-2021-06-20-19-22-04 753102](https://user-images.githubusercontent.com/38226087/122736460-580fa800-d280-11eb-879c-25f99dafc887.png)

It is my assumption that the Selenium agent fails to write in the text editor as some of the GUI elements are not in the current viewport.

## Changes

The changes in this pull request makes the agent scroll to the GUI elements that it will click on or type in before it performs the action.

## Results

**Before:**

```shell
Summary run status                                                                  FAIL

Artifacts dir                                                                       2021-06-20_19-16-25
OS                                                                                  Linux
DC Apps Performance Toolkit version                                                 4.2.0
Application                                                                         jsm 4.13.4
Dataset info                                                                        1004433 issues
Application nodes count                                                             1
Concurrency                                                                         200
Expected test run duration from yml file                                            2700 sec
Actual test run duration                                                            2919 sec
Finished                                                                            (True, 'OK')
Compliant                                                                           (True, 'OK')
Success                                                                             (False, 'One or more actions have success rate < 95.0 %.')
Has app-specific actions                                                            False

Action                                                                             Success Rate        90th Percentile     Status
jmeter_agent_login_and_view_dashboard                                               100.0               0.43                OK
jmeter_agent_add_comment:open_request_comment                                       100.0               0.01                OK
jmeter_agent_add_comment:save_request_comment                                       100.0               0.41                OK
jmeter_agent_view_request                                                           100.0               0.23                OK
jmeter_agent_browse_projects                                                        100.0               0.06                OK
jmeter_agent_view_customers                                                         100.0               0.76                OK
jmeter_agent_view_report_workload_small                                             100.0               0.92                OK
jmeter_agent_view_queues_small:all_open_queue                                       100.0               7.62                OK
jmeter_agent_view_queues_small:random_queue                                         100.0               0.35                OK
jmeter_agent_view_queues_medium:all_open_queue                                      100.0               1.26                OK
jmeter_agent_view_queues_medium:random_queue                                        100.0               0.36                OK
jmeter_agent_view_report_workload_medium                                            100.0               0.74                OK
jmeter_agent_view_report_created_vs_resolved_medium                                 100.0               0.17                OK
jmeter_agent_view_report_created_vs_resolved_small                                  100.0               0.15                OK
jmeter_customer_login_and_view_portals                                              100.0               0.58                OK
jmeter_customer_view_requests:my_requests                                           100.0               0.27                OK
jmeter_customer_view_requests:all_requests                                          100.0               0.28                OK
jmeter_customer_view_requests:with_filter_requests                                  100.0               0.19                OK
jmeter_customer_view_request                                                        100.0               0.18                OK
jmeter_customer_view_portal                                                         100.0               0.12                OK
jmeter_customer_create_request:open_create_request_view                             100.0               0.12                OK
jmeter_customer_create_request:create_request                                       100.0               0.49                OK
jmeter_customer_create_request:view_request_after_creation                          100.0               0.15                OK
jmeter_customer_share_request_with_org:search_org                                   100.0               0.02                OK
jmeter_customer_share_request_with_org:add_org                                      100.0               0.58                OK
jmeter_customer_share_request_with_org:remove_org                                   100.0               0.64                OK
jmeter_customer_add_comment                                                         100.0               0.19                OK
jmeter_customer_share_request_with_customer:search_customer                         100.0               0.04                OK
jmeter_customer_share_request_with_customer:add_customer                            100.0               0.54                OK
jmeter_customer_share_request_with_customer:remove_customer                         100.0               0.67                OK
selenium_agent_login:open_login_page                                                100.0               0.13                OK
selenium_customer_login:open_login_page                                             100.0               0.1                 OK
selenium_agent_login:login_and_view_dashboard                                       100.0               0.61                OK
selenium_agent_login                                                                100.0               0.73                OK
selenium_agent_browse_projects                                                      100.0               0.25                OK
selenium_customer_login:login_and_view_portal                                       100.0               0.68                OK
selenium_customer_login                                                             100.0               0.78                OK
selenium_customer_create_request:browse_all_portals                                 100.0               0.59                OK
selenium_customer_create_request:view_portal                                        100.0               0.19                OK
selenium_customer_create_request:choose_request_type                                100.0               0.59                OK
selenium_agent_view_customers                                                       100.0               0.74                OK
selenium_customer_create_request:create_and_submit_request                          100.0               1.05                OK
selenium_customer_create_request                                                    100.0               2.35                OK
selenium_agent_view_request                                                         100.0               0.56                OK
selenium_customer_view_request                                                      100.0               0.36                OK
selenium_customer_view_requests                                                     100.0               0.41                OK
selenium_agent_view_report_workload_medium                                          100.0               1.2                 OK
selenium_customer_view_all_requests                                                 100.0               0.37                OK
selenium_agent_view_report_created_vs_resolved_medium                               100.0               0.74                OK
selenium_agent_view_report_workload_small                                           100.0               1.24                OK
selenium_agent_view_report_created_vs_resolved_small                                100.0               0.73                OK
selenium_customer_share_request_with_customer:search_for_customer_to_share_with     100.0               2.62                OK
selenium_customer_share_request:share_request_with_customer                         100.0               1.6                 OK
selenium_customer_share_request_with_customer                                       100.0               4.21                OK
selenium_agent_add_comment:add comment                                              94.0                1.74                Fail
selenium_agent_add_comment                                                          94.0                2.23                Fail
selenium_customer_add_comment                                                       100.0               0.94                OK
selenium_customer_log_out                                                           100.0               0.21                OK
selenium_agent_view_queues_large_project_:all_open_queue                            100.0               1.6                 OK
selenium_agent_view_queues_large_project:random_choice_queue                        100.0               0.29                OK
selenium_agent_view_queues_large_project                                            100.0               1.85                OK
selenium_agent_view_queues_small_project_:all_open_queue                            100.0               4.78                OK
selenium_agent_view_queues_small_project:random_choice_queue                        99.0                0.34                OK
selenium_agent_view_queues_small_project                                            99.0                5.1                 OK
selenium_agent_logout                                                               100.0               0.32                OK
```

**After:**
```shell
Summary run status                                                                  OK

Artifacts dir                                                                       2021-06-21_07-26-48
OS                                                                                  Linux
DC Apps Performance Toolkit version                                                 4.2.0
Application                                                                         jsm 4.13.4
Dataset info                                                                        1009277 issues
Application nodes count                                                             1
Concurrency                                                                         200
Expected test run duration from yml file                                            2700 sec
Actual test run duration                                                            2919 sec
Finished                                                                            (True, 'OK')
Compliant                                                                           (True, 'OK')
Success                                                                             (True, 'OK')
Has app-specific actions                                                            False

Action                                                                             Success Rate        90th Percentile     Status
jmeter_agent_login_and_view_dashboard                                               100.0               0.46                OK
jmeter_agent_add_comment:open_request_comment                                       100.0               0.02                OK
jmeter_agent_add_comment:save_request_comment                                       100.0               0.46                OK
jmeter_agent_view_request                                                           100.0               0.26                OK
jmeter_agent_browse_projects                                                        100.0               0.07                OK
jmeter_agent_view_customers                                                         100.0               0.79                OK
jmeter_agent_view_queues_small:all_open_queue                                       100.0               7.87                OK
jmeter_agent_view_queues_small:random_queue                                         100.0               0.36                OK
jmeter_agent_view_report_workload_small                                             100.0               1.11                OK
jmeter_agent_view_queues_medium:all_open_queue                                      100.0               1.81                OK
jmeter_agent_view_queues_medium:random_queue                                        100.0               0.38                OK
jmeter_agent_view_report_workload_medium                                            100.0               0.77                OK
jmeter_agent_view_report_created_vs_resolved_medium                                 100.0               0.19                OK
jmeter_agent_view_report_created_vs_resolved_small                                  100.0               0.16                OK
jmeter_customer_login_and_view_portals                                              100.0               0.59                OK
jmeter_customer_view_requests:my_requests                                           100.0               0.32                OK
jmeter_customer_view_requests:all_requests                                          100.0               0.32                OK
jmeter_customer_view_requests:with_filter_requests                                  100.0               0.23                OK
jmeter_customer_view_request                                                        100.0               0.2                 OK
jmeter_customer_view_portal                                                         100.0               0.14                OK
jmeter_customer_create_request:open_create_request_view                             100.0               0.13                OK
jmeter_customer_create_request:create_request                                       100.0               0.54                OK
jmeter_customer_create_request:view_request_after_creation                          100.0               0.17                OK
jmeter_customer_share_request_with_org:search_org                                   100.0               0.02                OK
jmeter_customer_share_request_with_org:add_org                                      100.0               0.6                 OK
jmeter_customer_share_request_with_org:remove_org                                   100.0               0.65                OK
jmeter_customer_add_comment                                                         100.0               0.21                OK
jmeter_customer_share_request_with_customer:search_customer                         100.0               0.04                OK
jmeter_customer_share_request_with_customer:add_customer                            100.0               0.55                OK
jmeter_customer_share_request_with_customer:remove_customer                         100.0               0.72                OK
selenium_customer_login:open_login_page                                             100.0               0.1                 OK
selenium_agent_login:open_login_page                                                100.0               0.13                OK
selenium_customer_login:login_and_view_portal                                       100.0               0.69                OK
selenium_customer_login                                                             100.0               0.79                OK
selenium_agent_login:login_and_view_dashboard                                       100.0               0.63                OK
selenium_agent_login                                                                100.0               0.76                OK
selenium_agent_browse_projects                                                      100.0               0.26                OK
selenium_customer_create_request:browse_all_portals                                 100.0               0.6                 OK
selenium_customer_create_request:view_portal                                        100.0               0.2                 OK
selenium_agent_view_customers                                                       100.0               0.75                OK
selenium_customer_create_request:choose_request_type                                100.0               0.59                OK
selenium_agent_view_request                                                         100.0               0.56                OK
selenium_customer_create_request:create_and_submit_request                          100.0               1.06                OK
selenium_customer_create_request                                                    100.0               2.4                 OK
selenium_customer_view_request                                                      100.0               0.37                OK
selenium_customer_view_requests                                                     100.0               0.46                OK
selenium_customer_view_all_requests                                                 100.0               0.42                OK
selenium_agent_view_report_workload_medium                                          100.0               1.21                OK
selenium_agent_view_report_created_vs_resolved_medium                               100.0               0.75                OK
selenium_agent_view_report_workload_small                                           100.0               1.25                OK
selenium_customer_share_request_with_customer:search_for_customer_to_share_with     100.0               2.63                OK
selenium_agent_view_report_created_vs_resolved_small                                100.0               0.73                OK
selenium_customer_share_request:share_request_with_customer                         100.0               1.6                 OK
selenium_customer_share_request_with_customer                                       100.0               4.23                OK
selenium_customer_add_comment                                                       100.0               0.97                OK
selenium_agent_add_comment:add comment                                              100.0               1.79                OK
selenium_agent_add_comment                                                          100.0               2.3                 OK
selenium_customer_log_out                                                           100.0               0.22                OK
selenium_agent_view_queues_large_project_:all_open_queue                            100.0               1.87                OK
selenium_agent_view_queues_large_project:random_choice_queue                        100.0               0.3                 OK
selenium_agent_view_queues_large_project                                            100.0               2.14                OK
selenium_agent_view_queues_small_project_:all_open_queue                            100.0               5.0                 OK
selenium_agent_view_queues_small_project:random_choice_queue                        98.0                0.35                OK
selenium_agent_view_queues_small_project                                            98.0                5.33                OK
selenium_agent_logout                                                               100.0               0.32                OK
```