### PR TITLE
DCA-1397 bump taurus version up to 1.16.0

### DIFF
--- a/app/locustio/common_utils.py
+++ b/app/locustio/common_utils.py
@@ -229,18 +229,18 @@ def global_measure(func, start_time, interaction, *args, **kwargs):
     except Exception as e:
         total = int((time.time() - start_time) * 1000)
         print(e)
-        events.request_failure.fire(request_type="Action",
-                                    name=interaction,
-                                    response_time=total,
-                                    response_length=0,
-                                    exception=e)
+        events.request.fire(request_type="Action",
+                            name=interaction,
+                            response_time=total,
+                            response_length=0,
+                            exception=e)
         logger.error(f'{interaction} action failed. Reason: {e}')
     else:
         total = int((time.time() - start_time) * 1000)
-        events.request_success.fire(request_type="Action",
-                                    name=interaction,
-                                    response_time=total,
-                                    response_length=0)
+        events.request.fire(request_type="Action",
+                            name=interaction,
+                            response_time=total,
+                            response_length=0)
         logger.info(f'{interaction} is finished successfully')
     return result
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib==3.4.3
 pandas==1.3.4
-bzt==1.15.4
+bzt==1.16.0
 pytest==6.2.5
 locust==2.5.0
 selenium==3.141.0


### PR DESCRIPTION
Locust has deprecated `request_success` and `request_failure` hooks.
