### PR TITLE
delete function annotantios for return type

### DIFF
--- a/app/util/jtl_convertor/jtls-to-csv.py
+++ b/app/util/jtl_convertor/jtls-to-csv.py
@@ -117,7 +117,7 @@ def __validate_file_names(file_names: List[str]):
         file_names_set.add(file_name_without_extension)
 
 
-def __pathname_pattern_expansion(args: List[str]) -> list[str]:
+def __pathname_pattern_expansion(args: List[str]):
     file_names: List[str] = []
     for arg in args:
         file_names.extend([os.path.basename(x) for x in glob(str(ENV_TAURUS_ARTIFACT_DIR / arg))])


### PR DESCRIPTION
delete function annotantios for return type.
I get the following error in my environment.

19:09:48 WARNING: Errors for python util/jtl_convertor/jtls-to-csv.py kpi.jtl selenium.jtl:
Traceback (most recent call last):
  File "util/jtl_convertor/jtls-to-csv.py", line 120, in <module>
    def __pathname_pattern_expansion(args: List[str]) -> list[str]:
TypeError: 'type' object is not subscriptable

19:09:49 ERROR: CalledProcessError: Command 'python util/jtl_convertor/jtls-to-csv.py kpi.jtl selenium.jtl' returned non-zero exit status 1.
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/cli.py", line 276, in perform
    self.engine.run()
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/engine/engine.py", line 277, in run
    reraise(exc_info, exc_value)
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/utils.py", line 106, in reraise
    raise exc
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/engine/engine.py", line 267, in run
    self._shutdown()
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/engine/engine.py", line 338, in _shutdown
    reraise(exc_info, exc_value)
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/utils.py", line 106, in reraise
    raise exc
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/engine/engine.py", line 325, in _shutdown
    module.shutdown()
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/modules/shellexec.py", line 121, in shutdown
    task.start()
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/modules/shellexec.py", line 190, in start
    self._get_results()
  File "/Users/amaya/work/lab/dc-app-performance-toolkit/venv/lib/python3.8/site-packages/bzt/modules/shellexec.py", line 217, in _get_results
    raise CalledProcessError(self.process.returncode, self)