### PR TITLE
Add pytests to atlassians latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ outputs/
 *.pyc
 local_*.yml
 **jmeter.properties
+app/pytests/deleteCreatedObjects

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -40,6 +40,7 @@ settings:
 services:
   - module: shellexec
     prepare:
+      - pip install pytest-parallel # DM Dag
       - python util/pre_run/environment_checker.py
       - python util/pre_run/check_for_updates.py
       - python util/data_preparation/jira_prepare_data.py
@@ -62,7 +63,15 @@ execution:
     executor: selenium
     runner: pytest
     hold-for: ${test_duration}
+  - scenario: pytest-run
+    executor: pytest
+    runner: pytest
+    hold-for: ${test_duration}
+    ramp-up: 3m
 scenarios:
+  pytest-run:
+    additional-args: --workers 8 --tests-per-worker 25
+    script: pytests/
   selenium:
     script: selenium_ui/jira_ui.py
   locust:

--- a/app/pytests/cleanup.py
+++ b/app/pytests/cleanup.py
@@ -1,0 +1,8 @@
+import os
+os.system('pytest -sq delete.py')
+os.system('cp projects projectsOLD')
+os.system('rm projects')
+os.system('cp deleteCreatedObjects deleteCreatedObjectsOLD')
+os.system('rm deleteCreatedObjects')
+
+os.system('pytest -sq deleteAll.py')

--- a/app/pytests/cleanupObjCreatedDuringRun.py
+++ b/app/pytests/cleanupObjCreatedDuringRun.py
@@ -1,0 +1,3 @@
+import os
+os.system('pytest -sq deleteObjCreatedDuringRun.py')
+

--- a/app/pytests/conftest.py
+++ b/app/pytests/conftest.py
@@ -1,0 +1,185 @@
+import os
+import datetime
+from pathlib import Path
+import time
+import sys
+import json
+import inspect
+import threading
+import os
+from os import path
+global_lock = threading.Lock()
+global_lock_pytest_result = threading.Lock()
+import random
+
+JTL_HEADER = "timeStamp,elapsed,label,responseCode,responseMessage,threadName,success,bytes,grpThreads,allThreads," \
+             "Latency,Hostname,Connect\n"
+HOSTNAME = os.environ.get('application_hostname')
+
+PRINT_IN_SHELL = os.environ.get('print_in_shell')
+
+
+def pytest_addoption(parser):
+    parser.addoption('--repeat', action='store',
+                     help='Number of times to repeat each test')
+
+def print_in_shell(*values):
+    if PRINT_IN_SHELL=="No":
+        pass
+    else:
+        print(*values)
+
+
+def __get_current_results_dir():
+    if 'TAURUS_ARTIFACTS_DIR' in os.environ:
+        return os.environ.get('TAURUS_ARTIFACTS_DIR')
+    else:
+        #   raise SystemExit('Taurus result directory could not be found')
+        results_dir_name = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        #  pytest_run_results = f'../results/{results_dir_name}_local'
+        pytest_run_results = f'results/{results_dir_name}_local'
+        if os.path.isdir(f'results/'):
+            pass
+        else:
+            os.mkdir(f'results/')
+        if os.path.isdir(pytest_run_results):
+            print ("Dir exist")
+        else:
+            os.mkdir(pytest_run_results)
+        return pytest_run_results  # in case you just run pytest
+
+
+# create selenium output files
+current_results_dir = __get_current_results_dir()
+basepath = path.dirname(__file__)
+pytest_results_file = Path(current_results_dir + '/pytests_run.jtl')
+pytest_error_file = Path(current_results_dir + '/pytests_run.err')
+#w3c_timings_pytest_file = Path(current_results_dir + '/w3c_timings_pytests.txt')
+#print("wc3_timing_pytest_file:" + current_results_dir +  '/w3c_timings_pytests.txt')
+delete_created_objects_path = path.abspath(path.join(basepath, "deleteCreatedObjects"))
+
+#CURRENT_PATH = pathlib.Path().absolute()
+projects_path = path.abspath(path.join(basepath, "projects"))
+
+if not pytest_results_file.exists():
+    global_lock_pytest_result.acquire()
+    with open(pytest_results_file, "w") as file:
+        file.write(JTL_HEADER)
+    global_lock_pytest_result.release()
+#    with open(w3c_timings_pytest_file, 'w'):
+#        pass
+
+def readProjectCmd():
+    result = []
+    try:
+        with open(projects_path, "r") as fp:
+            line = fp.readline()
+            while line:
+                dict = eval(line)
+                result.append(dict)
+                line = fp.readline()
+    except IOError:
+        print("File not accessible read " + 'project')
+    return result
+
+projects = readProjectCmd()
+
+def writeLockedCmd(delete_request, type , id):
+    global global_lock
+    try:
+        global_lock.acquire()
+        with open(delete_created_objects_path, "a") as f:
+            f.write(delete_request)
+            f.close()
+        global_lock.release()
+    except IOError:
+        print("Write to deleteCreateObjects file failed" + type +  id)
+        global_lock.release()
+
+def saveRemoveDiagramCmd(diagramId):
+    diagrams_delete_request ='/rest/dependency-map/1.0/diagram/' + str(diagramId) + '\n'
+    writeLockedCmd(diagrams_delete_request, "Diagram" , diagramId)
+
+
+def saveRemoveIssueLinkCmd(issueLinkId):
+    issueLink_delete_request ='/rest/api/latest/issueLink/' + str(issueLinkId) + '\n'
+    writeLockedCmd(issueLink_delete_request, "IssuLink" , issueLinkId)
+
+def getRandomFilter(session):
+    project = getRandomProject()
+    filterKey = project["filterId"]
+    return filterKey
+
+def getRandomProjectId():
+    nrProjects = len(projects)
+    projectId=projects[random.randint(0,nrProjects-1)]['id']
+    return projectId
+
+def getRandomProject():
+    nrProjects = len(projects)
+    project=projects[random.randint(0,nrProjects-1)]
+    return project
+
+
+
+def print_timing(func):
+    def wrapper(self , base_url, session):
+        start = time.time()
+        error_msg = 'Success'
+        full_exception = ''
+        interaction = func.__qualname__
+        try:
+            func(self, base_url, session)
+            success = True
+        except Exception:
+            success = False
+            # https://docs.python.org/2/library/sys.html#sys.exc_info
+            exc_type, full_exception = sys.exc_info()[:2]
+            error_msg = exc_type.__name__
+        end = time.time()
+        timing = str(int((end - start) * 1000))
+        timestamp = round(time.time() * 1000)
+
+        global_lock.acquire()
+        with open(pytest_results_file, "a") as file:
+            file.write(f"{timestamp},{timing},{interaction},,{error_msg},,{success},0,0,0,0,,0\n")
+        global_lock.release()
+
+        print(f"{timestamp},{timing},{interaction},{error_msg},{success}")
+
+        if not success:
+            raise Exception(error_msg, full_exception)
+
+    return wrapper
+
+def print_timing_with_additional_arg(func):
+    def wrapper(self , base_url, session, create_data):
+        start = time.time()
+        error_msg = 'Success'
+        full_exception = ''
+        interaction = func.__qualname__
+        try:
+            func(self, base_url, session, create_data)
+            success = True
+        except Exception:
+            success = False
+            # https://docs.python.org/2/library/sys.html#sys.exc_info
+            exc_type, full_exception = sys.exc_info()[:2]
+            error_msg = exc_type.__name__
+        end = time.time()
+        timing = str(int((end - start) * 1000))
+
+
+        timestamp = round(time.time() * 1000)
+
+        global_lock.acquire()
+        with open(pytest_results_file, "a") as file:
+            file.write(f"{timestamp},{timing},{interaction},,{error_msg},,{success},0,0,0,0,,0\n")
+        global_lock.release()
+
+        print(f"{timestamp},{timing},{interaction},{error_msg},{success}")
+
+        if not success:
+            raise Exception(error_msg, full_exception)
+
+    return wrapper

--- a/app/pytests/create_diagrams.py
+++ b/app/pytests/create_diagrams.py
@@ -1,0 +1,135 @@
+import requests
+import json
+from fixtures import session
+from fixtures import base_url
+from conftest import readProjectCmd
+import os
+from os import path
+import random
+import pathlib
+
+HOSTNAME = os.environ.get('application_hostname')
+
+basepath = path.dirname(__file__)
+#CURRENT_PATH = pathlib.Path().absolute()
+out_file_path = path.abspath(path.join(basepath, "deleteCreatedObjects"))
+
+def getProjectIds(projectDict):
+    result = []
+    for project in projectDict:
+        result.append(project['id'])
+    return result
+
+class TestCreateDiagram:
+
+    def test_create_diagram(self, base_url, session):
+        #Get filter key
+        page = 0
+        projectDict = readProjectCmd()
+        projectIdList = getProjectIds(projectDict)
+        filterKeyList =[]
+        for  project in projectDict:
+            filterKeyList.append(project["filterId"])
+        print(str(filterKeyList))
+
+        with open(out_file_path, "a") as f:
+            # print( diagrams_response.json() );
+            for filterKey in filterKeyList:
+                print(filterKey)
+                for c in range(0, 10):
+                    diagramId = create_diagram(filterKey, session)
+                    diagrams_delete_request = '/rest/dependency-map/1.0/diagram/' + diagramId
+                    f.write(diagrams_delete_request)
+                    f.write("\n")
+        f.close()
+
+def create_diagram(filterKey, session):
+    # Get filter key
+    HOSTNAME = os.environ.get('application_hostname')
+
+    # Get field
+    field = 'priority'
+    print(field)
+
+    # Get field
+    field2 = 'status'
+    print(field)
+
+    # Get user
+    diagrams_response = session.get('/rest/dependency-map/1.0/user')
+    assert diagrams_response.status_code == 200
+    userKey = diagrams_response.json()["key"]
+    print("User key: " + userKey)
+
+    # Create diagram
+    payload = {
+      'name': "A100",
+      'author': userKey,
+      'layoutId': 2,
+      'filterId': filterKey,
+      'boxColorFieldKey': field,
+      'groupedLayoutFieldKey': field,
+      'matrixLayoutHorizontalFieldKey': field,
+      'matrixLayoutVerticalFieldKey': field2,
+      'showTypeIcons': True,
+      'parallelIssueBatches': 4,
+      'issuesPerRow': 5,
+      'secondaryIssues': 1,
+      'boxType': 0
+    }
+
+    diagram_response = session.post('/rest/dependency-map/1.0/diagram',
+                                    json=payload)
+    assert diagram_response.status_code == 200
+    diagramId = str(diagram_response.json()["id"])
+    print("New diagram id: " + diagramId)
+
+    # Create linkConfig
+    payload = {
+      'diagramId': diagramId,
+      'linkKey': 10000,
+      'visible': True,
+      'dashType': 0,
+      'width': 0,
+      'colorPaletteEntryId': 20
+    }
+
+    diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramId,
+                                     json=payload)
+
+
+
+    newLinkConfig = diagrams_response.json()
+    linkConfigId = str(newLinkConfig["id"])
+    print(linkConfigId)
+    assert(diagrams_response.status_code == 200)
+
+    change_color_mapping(session, diagramId)
+
+    return diagramId
+
+def change_color_mapping(session, diagramId):
+    HOSTNAME = os.environ.get('application_hostname')
+
+    # Get all priorities
+    diagrams_response = session.get('/rest/dependency-map/1.0/fieldOption/status')
+    assert diagrams_response.status_code == 200
+    nrOfFieldOptions=len(diagrams_response.json())
+    fieldIemList = diagrams_response.json()
+    #Nr of field options
+    print(nrOfFieldOptions)
+
+    for field in fieldIemList:
+        fieldOptionId = field["id"]
+        colorPaletteEntryId = random.randint(0,19)
+        #create box coloure resource entry
+        payload = {
+          "diagramId":diagramId,
+          "fieldId":"status",
+          "fieldOptionId":fieldOptionId,
+          "colorPaletteEntryId": colorPaletteEntryId
+        }
+        diagrams_response = session.post('/rest/dependency-map/1.0/boxColor', json=payload)
+        assert diagrams_response.status_code == 200
+        print( diagrams_response.json() )
+        #boxColorResource = diagrams_response.json()['id']

--- a/app/pytests/create_random_links.py
+++ b/app/pytests/create_random_links.py
@@ -1,0 +1,234 @@
+from fixtures import session
+from fixtures import base_url
+from fixtures import nr_projects
+import os
+from os import path
+import math
+import random
+import pathlib
+from itertools import islice
+
+
+basepath = path.dirname(__file__)
+#CURRENT_PATH = pathlib.Path().absolute()
+out_file_path = path.abspath(path.join(basepath, "deleteCreatedObjects"))
+
+#CURRENT_PATH = pathlib.Path().absolute()
+projects_path = path.abspath(path.join(basepath, "projects"))
+
+def saveRemoveFilterCmd(filterId):
+    filter_request ='/rest/api/2/filter/' + str(filterId) + '\n'
+    with open(out_file_path, "a") as f:
+        f.write(filter_request)
+        f.close()
+
+def saveProjectCmd(projectName, key, id, filterId):
+    try:
+        with open(projects_path, "a") as f:
+            project = {'projectName': projectName, 'key': key, 'id': id, 'filterId': filterId}
+            f.write(str (project))
+            f.write("\n")
+            f.close()
+    except IOError:
+        print("File not accessible write: " + projects_path)
+
+
+# returns the number of ways k elements can be chosen from n elements
+def binom(n, k):
+    return math.factorial(n) // math.factorial(k) // math.factorial(n - k)
+
+# returns the number in an issue key
+def issue_key_number(s):
+    return int(s.partition("-")[2])
+
+def get_link_type(session):
+    #JIRA Get list of available link types
+    issueLinkTypeId = 0
+    diagrams_response = session.get('/rest/api/2/issueLinkType', auth=('admin', 'admin'))
+    issueLinkTypes = diagrams_response.json()['issueLinkTypes']
+    for linkType in issueLinkTypes:
+        print(linkType)
+        if linkType["name"]=="Blocks":
+            issueLinkTypeId=linkType["id"]
+            break
+    print(issueLinkTypeId)
+    return issueLinkTypeId
+
+
+
+def get_projects(nr_projects, session):
+    resp = session.get('/rest/api/latest/project',auth=('admin', 'admin'))
+    assert resp.status_code == 200
+    result = resp.json()
+    return result
+
+def get_projects_with_permisions(nr_projects, session):
+    #Before running, there has to performance users in the DB.
+    projects = get_projects(nr_projects, session)
+ #   print("AllProjects: " + str(projects))
+    projects_with_perm = []
+    for project in projects:
+        projectKey = project['key']
+        diagrams_response = session.get(
+            "/rest/api/2/user/permission/search?permissions=ASSIGN_ISSUE&projectKey=" + projectKey + "&username=per", auth=('admin','admin'))
+#        print(str(diagrams_response.json()))
+        if (len(diagrams_response.json())) > 0:
+            projectId = project['id']
+            projects_with_perm.append(project)
+        if (len(projects_with_perm)>= nr_projects):
+            break
+    print ("PROJECTS WITH PERM:" + str(len(projects_with_perm )))
+    return projects_with_perm
+
+def get_filter(projectId, session):
+    page = 0
+    exit = 0
+    filterKey =""
+    print("PROJECT" + str( projectId ))
+    while True:
+        result_response = session.get('/rest/dependency-map/1.0/filter?searchTerm=&page=' + str(page) + '&resultsPerPage=50', auth=('admin','admin'))
+        assert result_response.status_code == 200
+        filter_response = result_response.json()["filters"]
+#        print ("all filters json: " + str(filter_response))
+        page = page + 1
+
+        if len(filter_response) ==0:
+            break
+
+        for filter in filter_response:
+            filter_id = str (filter['filterId'])
+ #           print("filter['filterId']" +filter_id)
+            permission_response = session.get('/rest/api/2/filter/' + filter_id + '/permission', auth=('admin','admin'))
+  #          print ("for filter: " + str(permission_response.json()))
+            for sharePer in permission_response.json():
+   #             print("Permission: " + str(sharePer))
+   #             print(sharePer['type']=='project')
+   #             print (sharePer['project']['id'] == projectId )
+   #             print("F2 SharePer['project']['id']" + sharePer['project']['id'])
+   #             print("F2 projectId" + projectId)
+                if sharePer['type']=='project' and  sharePer['project']['id'] == projectId   :
+                    filterKey=filter_id
+                    exit = 1
+                    break
+            if exit ==1:
+                break
+
+        if exit == 1:
+            break
+    return filterKey
+
+def create_filter_if_missing(projects, session):
+    #Before running, there has to performance users in the DB.
+    print("PROJECTS#" + str(projects))
+    for project in projects:
+        filterKey = get_filter(project["id"], session)
+        print("FilterKey" + filterKey)
+
+        if filterKey == "" :
+            # Create filter
+            jqlQuery = "project = " + project["key"]
+            print(jqlQuery)
+            payload = {"jql": jqlQuery,
+                "name": project["key"] + " NEW All issues",
+                "description": "List all issues"}
+            response = session.post(
+                '/rest/api/2/filter', json=payload, auth=('admin','admin'))
+            assert response.status_code == 200
+            result = response.json()
+            new_filter_id = result['id']
+            print("Filter created: " + new_filter_id)
+            filterKey=new_filter_id
+            saveRemoveFilterCmd(new_filter_id)
+            #Set filter permission
+            payloadPer = {"type": "group",
+                          "groupname": "jira-software-users"}
+            responsePer = session.post(
+                '/rest/api/2/filter/' + filterKey + "/permission", json=payloadPer, auth=('admin','admin'))
+            assert response.status_code == 200
+        saveProjectCmd(project['name'], project['key'], project['id'], filterKey)
+
+
+class TestCreateIssueLinks:
+    def test_create_issue_links(self, base_url, nr_projects, session):
+        # get all projects
+        projStartAt = 0
+
+        respProj = session.get('/rest/api/latest/project', auth=('admin', 'admin'))
+        projects = get_projects_with_permisions(nr_projects, session)
+        create_filter_if_missing(projects, session)
+
+        issueLinkTypeId = get_link_type(session)
+        assert respProj.status_code == 200
+        projects = respProj.json()
+        print("NR of projects: " + str(nr_projects))
+        if len(projects) > nr_projects:
+            projects = x = islice(projects, 0, nr_projects)
+        for project in projects:
+            project_key = project['key']
+            # collect keys of all issues in this project into issue_ids
+            link_percentage = 30
+            issue_ids = []
+            startAt = 0
+            while True:
+                resp = session.get(
+                    f'/rest/api/latest/search?maxResults=100&startAt={startAt}&jql=project={project_key}&fields=key',
+                    auth=('admin', 'admin'))
+                assert resp.status_code == 200
+                result = resp.json()
+                #         print(f"if {startAt} >= {result['total']}")
+                if startAt >= result['total'] or not ('issues' in result):
+                    break
+                issue_ids.extend(list(map(lambda issue: issue['id'], result['issues'])))
+                startAt = len(issue_ids)
+            if len(issue_ids) == 0:
+                break
+            # generate link_percentage random issue pairs out of issue_ids
+            # all pairs are in increasing order, to avoid link cycles
+            pair_count = min(len(issue_ids) * link_percentage / 100,
+                             binom(len(issue_ids), 2))  # limit wanted number of links by theoretical maximum
+            pairs = set()  # set of tuples, as tuples can be added to a set, but not lists
+            while len(pairs) < pair_count:
+                pair = tuple(sorted(random.sample(issue_ids, 2)))
+                if pair not in pairs:
+                    pairs.add(pair)
+            for pair in pairs:
+                print(pair)
+                self.create_link(session, issueLinkTypeId, pair[0], pair[1])
+        print("end")
+
+    def create_link(self, session, issueLinkTypeId, from_issue_id, to_issue_id):
+        #before
+        diagrams_response = session.get('/rest/api/2/issue/' + from_issue_id)
+        before_issue_links = diagrams_response.json()['fields']['issuelinks']
+        before_size = len(before_issue_links)
+
+        payload = { 'type': { 'id': issueLinkTypeId},  #blocks?
+                    'inwardIssue': { 'id': to_issue_id },
+                    'outwardIssue': { 'id': from_issue_id}}
+        diagrams_response = session.post('/rest/api/2/issueLink',
+                                     json= payload)
+
+        print(f"created link from issue {from_issue_id} to {to_issue_id} ")
+
+        #JIRA Get new issue links id
+        diagrams_response = session.get('/rest/api/2/issue/' + from_issue_id)
+        issueLinks = diagrams_response.json()['fields']['issuelinks']
+        #print(issueLinks)
+        if (len(issueLinks) > before_size):
+            issueLinksId = 0
+            for issueLink in issueLinks:
+                if 'inwardIssue' in issueLink and  issueLink['inwardIssue']:
+                   if  issueLink['inwardIssue']['id']==to_issue_id:
+                       issueLinksId = issueLink['id']
+
+            #issueLinksId = issueLinks[-1]['id']
+            print("New issue Links Id=" + issueLinksId);
+            if issueLinksId!=0:
+                try:
+                    with open(out_file_path, "a") as f:
+                        issueLink_delete_request ='/rest/api/latest/issueLink/' + issueLinksId
+                        f.write(issueLink_delete_request)
+                        f.write("\n")
+                        f.close()
+                except IOError:
+                    print("File not accessible delete...")

--- a/app/pytests/delete.py
+++ b/app/pytests/delete.py
@@ -1,0 +1,31 @@
+import requests
+import json
+from fixtures import base_url
+import os
+from os import path
+import pathlib
+
+basepath = path.dirname(__file__)
+#CURRENT_PATH = pathlib.Path().absolute()
+delete_diagram_file_path = path.abspath(path.join(basepath, "deleteCreatedObjects"))
+
+class TestDelete:
+    def test_delete(self,  base_url):
+        print("BASE_URL: " + base_url)
+        adminSession = requests.session()
+        auth_response = adminSession.post(base_url + '/rest/auth/1/session',
+                                          json={ "username": "admin", "password": "admin" })
+        resp = adminSession.get(base_url + '/rest/api/2/project')
+        assert resp.status_code == 200
+        try:
+            with open(delete_diagram_file_path) as f:
+                for line in f:
+                    deleteLine = line.strip();
+                    print(base_url + deleteLine)
+                    diagrams_response = adminSession.delete(base_url + deleteLine)
+                    print(diagrams_response)
+            f.close()
+        except FileNotFoundError:
+            print("File can not be found: " + str(delete_diagram_file_path))
+        except:
+            print("Something else went wrong")

--- a/app/pytests/deleteAll.py
+++ b/app/pytests/deleteAll.py
@@ -1,0 +1,34 @@
+import requests
+import json
+from fixtures import base_url
+import os
+from os import path
+import pathlib
+
+basepath = path.dirname(__file__)
+#CURRENT_PATH = pathlib.Path().absolute()
+delete_diagram_file_path = path.abspath(path.join(basepath, "deleteCreatedObjects"))
+
+class TestDeleteAllDiagrams:
+    def test_delete(self,  base_url):
+        adminSession = requests.session()
+        auth_response = adminSession.post(base_url + '/rest/auth/1/session',
+                                          json={ "username": "admin", "password": "admin" })
+        resp = adminSession.get(base_url + '/rest/api/2/project')
+        assert resp.status_code == 200
+        diagram_ids = []
+        startAt=0
+        while True:
+            resp =adminSession.get(base_url + f'/rest/dependency-map/1.0/diagram?searchTerm=&startAt={startAt}&maxResults=50')
+            assert resp.status_code == 200
+            result = resp.json()
+            if startAt >= result['total']  or not('values' in result):
+                break
+            diagram_ids.extend(list(map(lambda issue : issue['id'], result['values'])))
+            startAt = len(diagram_ids)
+
+        for diagram_id in  diagram_ids:
+            deleteLine = "/rest/dependency-map/1.0/diagram/" + str(diagram_id)
+            print(base_url + deleteLine)
+            diagrams_response = adminSession.delete(base_url + deleteLine)
+            print(diagrams_response)

--- a/app/pytests/deleteObjCreatedDuringRun.py
+++ b/app/pytests/deleteObjCreatedDuringRun.py
@@ -1,0 +1,31 @@
+import requests
+import json
+from fixtures import base_url
+import os
+from os import path
+import pathlib
+
+basepath = path.dirname(__file__)
+#CURRENT_PATH = pathlib.Path().absolute()
+delete_diagram_file_path = path.abspath(path.join(basepath, "deleteDuringRun"))
+
+class TestDelete:
+    def test_delete(self,  base_url):
+        print("BASE_URL: " + base_url)
+        adminSession = requests.session()
+        auth_response = adminSession.post(base_url + '/rest/auth/1/session',
+                                          json={ "username": "admin", "password": "admin" })
+        resp = adminSession.get(base_url + '/rest/api/2/project')
+        assert resp.status_code == 200
+        try:
+            with open(delete_diagram_file_path) as f:
+                for line in f:
+                    deleteLine = line.strip();
+                    print(base_url + deleteLine)
+                    diagrams_response = adminSession.delete(base_url + deleteLine)
+                    print(diagrams_response)
+            f.close()
+        except FileNotFoundError:
+            print("File can not be found: " + str(delete_diagram_file_path))
+        except:
+            print("Something else went wrong")

--- a/app/pytests/fixtures.py
+++ b/app/pytests/fixtures.py
@@ -1,0 +1,93 @@
+import pytest
+import requests
+import os
+import random
+import time
+import pathlib
+import yaml
+import json
+from os import path
+from requests import Session
+
+
+def env_settings():
+    basepath = path.dirname(__file__)
+    filepath = path.abspath(path.join(basepath, "..", "jira.yml"))
+    print(filepath)
+    with open(filepath) as file:
+        dict= yaml.load(file, yaml.FullLoader)
+    envSetting = dict['settings']['env']
+    return envSetting
+
+def get_hostname_port():
+    envSetting = env_settings()
+    print(envSetting)
+    hostname_port_var = 'http://' + envSetting['application_hostname'] + ':' + str(envSetting['application_port'])
+    return hostname_port_var
+
+
+BASE_URL = get_hostname_port()
+
+
+@pytest.fixture
+def base_url():
+    return BASE_URL
+
+@pytest.fixture
+def nr_projects():
+    envSettings = env_settings()
+    return envSettings['max_nr_projects_to_use']
+
+class LiveServerSession(Session):
+    def __init__(self, prefix_url=None, *args, **kwargs):
+        super(LiveServerSession, self).__init__(*args, **kwargs)
+        self.prefix_url = prefix_url
+    def request(self, method, url, *args, **kwargs):
+        url = self.prefix_url + url
+        return super(LiveServerSession, self).request(method, url, *args, **kwargs)
+
+
+# get list of all users - except 'admin' if more than one user
+
+print(BASE_URL);
+users_reponse = requests.get(BASE_URL  + '/rest/api/latest/user/search?username=performance_', auth=('admin', 'admin'))
+assert users_reponse.status_code == 200
+users = list(map(lambda user : user['name'], users_reponse.json()))
+if len(users) ==0:
+    print("There is no performance user")
+    users.append('admin')
+#print(users)
+
+
+
+
+# returns a random username/password dict
+# all users have password 'password', except user 'admin' that has password 'admin'
+def getRandomUsernamePassword():
+    username = random.choice(users)
+    password = 'password'
+    if username == 'admin':
+        password = 'admin'
+ #   print(username)
+ #   print("RETURN USER: " + username)
+    return {'username': username, 'password': password}
+
+# returns a logged in session for use in a test method
+@pytest.fixture(scope="class")
+def session():
+    #print("create session")
+    # authenticate to get a session id
+    s =  LiveServerSession(BASE_URL)
+    auth_response = s.post('/rest/auth/1/session',
+                           json=getRandomUsernamePassword())
+
+    # after test teardown
+    yield s  # provide the fixture value
+    #print("teardown session")
+    s.close()
+    return s
+
+# returns hostname_port
+#@pytest.fixture(scope="class")
+#def hostnameport():
+#    return get_hostname_port()

--- a/app/pytests/generatetests.py
+++ b/app/pytests/generatetests.py
@@ -1,0 +1,14 @@
+# The --repeat option will work for UnitTest classes in addition to pytest, otherwise you can use --count option
+def pytest_generate_tests(metafunc):
+    if metafunc.config.option.repeat is not None:
+        count = int(metafunc.config.option.repeat)
+
+        # We're going to duplicate these tests by parametrizing them,
+        # which requires that each test has a fixture to accept the parameter.
+        # We can add a new fixture like so:
+        metafunc.fixturenames.append('tmp_ct')
+
+        # Now we parametrize. This is what happens when we do e.g.,
+        # @pytest.mark.parametrize('tmp_ct', range(count))
+        # def test_foo(): pass
+        metafunc.parametrize('tmp_ct', range(count))

--- a/app/pytests/maxfreq.py
+++ b/app/pytests/maxfreq.py
@@ -1,0 +1,36 @@
+import functools
+import time
+
+# maxfreq 5 means func executes at most 5 times per
+# second (at least 1/5 seconds between)
+# If func is called less than 1/freq seconds since last call, it doesn't execute and None is returned
+def max_freq(maxfreq):
+    def decorator(func):
+        last_run_time = 0
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            nonlocal last_run_time
+            current_time = time.time()
+            if current_time - last_run_time > 1 / maxfreq:
+                last_run_time = current_time
+                return func(*args,**kwargs)
+            else:
+                return None
+        return wrapper
+    return decorator
+
+
+# demonstrate maxfreq:
+
+# @max_freq(maxfreq=2)
+# def afunc():
+#     print(f"afunc at {time.time()}")
+#
+# @max_freq(maxfreq=1.5)
+# def bfunc():
+#     print(f"bfunc at {time.time()}")
+#
+# for i in range(0, 99):
+#     afunc()
+#     bfunc()
+#     time.sleep(.1)

--- a/app/pytests/projects
+++ b/app/pytests/projects
@@ -1,0 +1,2 @@
+{'projectName': 'kan', 'key': 'KAN', 'id': '10001', 'filterId': '10001'}
+{'projectName': 'scr', 'key': 'SCR', 'id': '10000', 'filterId': '10000'}

--- a/app/pytests/setup.py
+++ b/app/pytests/setup.py
@@ -1,0 +1,6 @@
+import os
+os.system('pytest -sq create_random_links.py')
+os.system('pytest -sq create_diagrams.py')
+
+
+

--- a/app/pytests/test_change_diagram_config.py
+++ b/app/pytests/test_change_diagram_config.py
@@ -1,0 +1,79 @@
+import requests
+import json
+from conftest import print_timing
+from fixtures import session
+from fixtures import base_url
+from conftest import saveRemoveDiagramCmd
+from conftest import print_in_shell
+
+import os
+from maxfreq import max_freq
+import pathlib
+import pytest
+
+#POST /rest/dependency-map/1.0/diagram
+#POST /rest/dependency-map/1.0/linkConfig
+#GET /plugins/servlet/dependency-map/diagram
+#POST /rest/webResources/1.0/resources
+#GET /rest/dependency-map/1.0/diagram?searchTerm=&startAt=0&maxResults=50
+#POST /rest/webResources/1.0/resources
+
+class TestChangeDiagram:
+    @max_freq(50/3600)
+    @print_timing
+    def test_change_diagram_config(self, base_url, session):
+        HOSTNAME = os.environ.get('application_hostname')
+        # Get user
+        diagrams_response = session.get('/rest/dependency-map/1.0/user')
+        assert diagrams_response.status_code == 200
+        userKey = diagrams_response.json()["key"]
+        print_in_shell("User key: " + userKey)
+
+        # Create diagram
+        payload ={
+          'name':"D100",
+          'layoutId':0,
+          'filterKey': 10000,
+          'boxColorFieldKey': "priority",
+          'groupedLayoutFieldKey': "priority",
+          'matrixLayoutHorizontalFieldKey': 'fixVersions',
+          'matrixLayoutVerticalFieldKey': 'fixVersions',
+          'showTypeIcons': True,
+          'parallelIssueBatches': 4,
+          'issuesPerRow': 5,
+          'secondaryIssues': 1,
+          'boxType': 0
+        }
+        print_in_shell('payload=', payload)
+        diagrams_response = session.post('/rest/dependency-map/1.0/diagram',
+            json=payload)
+        print('diag resp=',str(diagrams_response.text))
+        assert diagrams_response.status_code == 200
+        newDiagram = diagrams_response.json()
+        diagramId = str(newDiagram["id"])
+        print_in_shell('diagramid=' +diagramId)
+
+        saveRemoveDiagramCmd(diagramId)
+
+        # Get all priorities
+        diagrams_response = session.get('/rest/dependency-map/1.0/fieldOption/priority')
+        assert diagrams_response.status_code == 200
+        priorityItem = diagrams_response.json()[4]
+        priorityItemId = str(priorityItem['id'])
+        print_in_shell('priorityItemId=' + priorityItemId)
+
+        #Get colore palete entry for diagram for field=priority option=5
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramId)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+        if not value:
+           print_in_shell( "No response value")
+        else:
+           print_in_shell( diagrams_response.json() )
+
+        #create box coloure resource entry
+        payload = {"diagramId":diagramId,"fieldKey":"priority","fieldOptionId":priorityItemId,"colorPaletteEntryId":4}
+        diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+            json=payload)
+        assert diagrams_response.status_code == 200
+        print_in_shell( diagrams_response.json() )

--- a/app/pytests/test_copy_diagram.py
+++ b/app/pytests/test_copy_diagram.py
@@ -1,0 +1,29 @@
+import requests
+from conftest import print_timing
+from fixtures import session
+from fixtures import base_url
+from conftest import saveRemoveDiagramCmd
+from conftest import print_in_shell
+import os
+import random
+import pathlib
+from maxfreq import max_freq
+
+class TestCopyDiagram:
+    @max_freq(50/3600)
+#    @print_timing
+    def test_copy_diagram(self, base_url, session):
+        HOSTNAME = os.environ.get('application_hostname')
+
+        #create a copy of the diagram
+        diagrams_response = session.get('/rest/dependency-map/1.0/diagram?searchTerm=&startAt=0&maxResults=50')
+        assert diagrams_response.status_code == 200
+        result = diagrams_response.json()['values']
+        if len(result)>0:
+            diagramId=result[0]['id']
+            print_in_shell('diagramId to copy', diagramId)
+            #create a copy of the diagram
+            diagrams_response = session.post('/rest/dependency-map/1.0/diagram/duplicate/' + str(diagramId) )
+            assert diagrams_response.status_code == 200
+            diagramId = diagrams_response.json()
+            saveRemoveDiagramCmd(diagramId)

--- a/app/pytests/test_create_link_config.py
+++ b/app/pytests/test_create_link_config.py
@@ -1,0 +1,75 @@
+import requests
+import json
+from conftest import print_timing
+from fixtures import session
+from fixtures import base_url
+from conftest import saveRemoveDiagramCmd
+import os
+from maxfreq import max_freq
+from conftest import print_in_shell
+
+class TestLinkConfig:
+    @max_freq(500/3600)
+    @print_timing
+    def test_create_change_link(self, base_url, session):
+        HOSTNAME = os.environ.get('application_hostname')
+        # Get user
+        diagrams_response = session.get('/rest/dependency-map/1.0/user')
+        assert diagrams_response.status_code == 200
+        userKey = diagrams_response.json()["key"]
+        print_in_shell("User key: " + userKey)
+
+        # Create diagram
+        payload = {
+          'name':"E100",
+          'layoutId':0,
+          'filterKey': 10000,
+          'boxColorFieldKey': "priority",
+          'groupedLayoutFieldKey': "priority",
+          'matrixLayoutHorizontalFieldKey': 'fixVersions',
+          'matrixLayoutVerticalFieldKey': 'fixVersions',
+          'showTypeIcons': True,
+          'parallelIssueBatches': 4,
+          'issuesPerRow': 5,
+          'secondaryIssues': 1,
+          'boxType': 0
+        }
+        diagrams_response = session.post('/rest/dependency-map/1.0/diagram',
+            json=payload)
+
+        newDiagram = diagrams_response.json()
+        print('newDiagram=', newDiagram)
+        diagramId = str(newDiagram["id"])
+        saveRemoveDiagramCmd(diagramId)
+
+        #JIRA Get list of available link types
+        diagrams_response = session.get('/rest/api/2/issueLinkType')
+        issueLinkTypeId = diagrams_response.json()['issueLinkTypes'][0]['id']
+        print_in_shell("issueLinkTypeId=" + issueLinkTypeId)
+        print_in_shell( diagrams_response.json() )
+
+        # Get all link configs
+        diagrams_response = session.get('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramId)
+        print_in_shell("all link configs")
+        print_in_shell( diagrams_response.json() )
+
+        # Create linkConfig
+        payload = { 'diagramId': diagramId, 'linkKey': 10000, 'visible': True, 'dashType': 0, 'width': 0, 'colorPaletteEntryId': 20}
+
+        diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramId,
+            json=payload)
+
+        newLinkConfig = diagrams_response.json()
+        print('newLinkConfig=', newLinkConfig)
+        assert(diagrams_response.status_code == 200)
+
+        # Update linkConfig
+        payload = {'diagramId': diagramId, 'linkKey': 10000, 'visible': True, 'dashType': 1, 'width': 2, 'colorPaletteEntryId': 39}
+
+        diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig',
+            json=payload)
+        assert(diagrams_response.status_code == 200)
+
+        # Get all link configs
+        diagrams_response = session.get('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramId)
+        print_in_shell( diagrams_response.json() )

--- a/app/pytests/test_delete_diagram.py
+++ b/app/pytests/test_delete_diagram.py
@@ -1,0 +1,64 @@
+import requests
+from conftest import print_timing
+from fixtures import session
+from fixtures import base_url
+import os
+from maxfreq import max_freq
+from conftest import print_in_shell
+from conftest import getRandomFilter
+
+class TestDelete:
+    @max_freq(50/3600)
+#    @print_timing
+    def test_delete_diagram(self, base_url, session):
+        # Prepare
+        # request list of diagrams using the session id
+        HOSTNAME = os.environ.get('application_hostname')
+        diagrams_response = session.get('/rest/dependency-map/1.0/diagram?searchTerm=&startAt=0&maxResults=50')
+        assert diagrams_response.status_code == 200
+
+        # To make it thread save need to create the diagram before removing
+
+        # Get user
+        diagrams_response = session.get('/rest/dependency-map/1.0/user')
+        assert diagrams_response.status_code == 200
+        userKey = diagrams_response.json()["key"]
+
+        # Get filter key
+        diagrams_response = session.get('/rest/dependency-map/1.0/filter?searchTerm=&page=0&resultsPerPage=25')
+        assert diagrams_response.status_code == 200
+
+        #Get filterKey randomly among the project in the project file
+        filterKey= getRandomFilter(session)
+
+        # Create diagram
+        payload ={
+          'name':"F100",
+          'author':userKey,
+          'layoutId':2,
+          'filterKey': filterKey,
+          'boxColorFieldKey': 'status',
+          'groupedLayoutFieldKey': 'status',
+          'matrixLayoutHorizontalFieldKey': 'status',
+          'matrixLayoutVerticalFieldKey': 'priority',
+          'showTypeIcons': True,
+          'parallelIssueBatches': 4,
+          'issuesPerRow': 5,
+          'secondaryIssues': 1,
+          'boxType': 0
+        }
+
+        diagrams_response = session.post('/rest/dependency-map/1.0/diagram',
+                                         json=payload)
+        assert diagrams_response.status_code == 200
+        diagramId = diagrams_response.json()['id']
+
+        #remove
+        diagrams_response2 = session.delete('/rest/dependency-map/1.0/diagram/' + str(diagramId))
+        assert diagrams_response2.status_code == 200
+        print_in_shell("Diagram removed" +  str(diagramId))
+        #print_in_shell( diagrams_response.json() );
+
+        #get all diagrams after delete
+        diagrams_response = session.get('/rest/dependency-map/1.0/diagram?searchTerm=&startAt=0&maxResults=50')
+        assert diagrams_response.status_code == 200

--- a/app/pytests/test_flow_create_diagram.py
+++ b/app/pytests/test_flow_create_diagram.py
@@ -1,0 +1,176 @@
+import requests
+from conftest import print_timing
+from fixtures import session
+from fixtures import base_url
+from conftest import saveRemoveDiagramCmd
+import pytest
+import time
+import os
+import random
+from maxfreq import max_freq
+from conftest import print_in_shell
+from conftest import getRandomFilter
+
+class TestFlowCreateDiagram:
+
+    @max_freq(50/3600)
+    @print_timing
+    def test_show_dependency_maps_flow_cd(self, base_url, session):
+
+        #Select Dependency Map
+        #GET /rest/dependency-map/1.0/diagram?searchTerm=&startAt=0&maxResults=50 HTTP/1.1" 200 1630 3
+        #GET /rest/api/2/filter/10000 HTTP/1.1" 200 631 2
+        #GET /rest/api/2/filter/10001 HTTP/1.1" 200 632 2
+        #GET /rest/api/2/user?key=admin HTTP/1.1" 200 344 1
+
+        start = time.time()
+
+        diagram_ids = []
+        startAt = 0
+
+        #Get all diagrams
+        HOSTNAME = os.environ.get('application_hostname')
+        while True:
+            resp =session.get(f'/rest/dependency-map/1.0/diagram?searchTerm=&startAt={startAt}&maxResults=50')
+            assert resp.status_code == 200
+            result = resp.json()
+            if startAt >= result['total'] or startAt > 500 or not('values' in result):
+                break
+            diagram_ids.extend(list(map(lambda issue : issue['id'], result['values'])))
+            startAt = len(diagram_ids)
+         #   print_in_shell(startAt)
+
+
+        # Get filter key
+        diagrams_response = session.get('/rest/dependency-map/1.0/filter?searchTerm=&page=0&resultsPerPage=25')
+        assert diagrams_response.status_code == 200
+
+        filterKey1=  getRandomFilter(session)
+        filterKey2=  getRandomFilter(session)
+        while filterKey1==filterKey2:
+            filterKey2= getRandomFilter(session)
+
+        # Get filter 10000  ?Scrum?
+        diagrams_response = session.get('/rest/api/2/filter/' + filterKey1)
+        assert diagrams_response.status_code == 200
+
+        # Get filter 10001 ?Kanban?
+        diagrams_response = session.get('/rest/api/2/filter/'+ filterKey2)
+        assert diagrams_response.status_code == 200
+
+        # Get user
+        diagrams_response = session.get('/rest/dependency-map/1.0/user')
+        assert diagrams_response.status_code == 200
+        userKey = diagrams_response.json()["key"]
+        #print_in_shell(userKey)
+
+    @max_freq(50/3600)
+    @print_timing
+    def test_create_diagram_flow_cd(self, base_url, session):
+        # Create Diagram
+
+        #JIRA Get list of available link types
+        HOSTNAME = os.environ.get('application_hostname')
+        diagrams_response = session.get('/rest/api/2/issueLinkType')
+        assert diagrams_response.status_code == 200
+
+        # Get filter key
+        diagrams_response = session.get('/rest/dependency-map/1.0/filter?searchTerm=&page=0&resultsPerPage=25')
+        assert diagrams_response.status_code == 200
+
+        # Get filter key
+        diagrams_response = session.get('/rest/dependency-map/1.0/filter?searchTerm=&page=0&resultsPerPage=25')
+        assert diagrams_response.status_code == 200
+
+        # Get filter key
+        diagrams_response = session.get('/rest/dependency-map/1.0/filter?searchTerm=&page=0&resultsPerPage=25')
+        assert diagrams_response.status_code == 200
+
+        #Get filterKey randomly among the project in the project file
+        filterKey= getRandomFilter(session)
+
+        #Get color palet entry
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?paletteId=' + '1')
+        assert diagrams_response.status_code == 200
+
+        # Get field options - status
+        diagrams_response = session.get('/rest/dependency-map/1.0/fieldOption/status')
+        assert diagrams_response.status_code == 200
+
+        #Get color palet entries
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?paletteId=' + '0')
+        assert diagrams_response.status_code == 200
+
+        # Get user
+        diagrams_response = session.get('/rest/dependency-map/1.0/user')
+        assert diagrams_response.status_code == 200
+        userKey = diagrams_response.json()["key"]
+
+        # Create diagram
+        payload ={
+          'name': "A100",
+          'layoutId': 2,
+          'filterKey': filterKey,
+          'boxColorFieldKey': 'priority',
+          'groupedLayoutFieldKey': 'priority',
+          'matrixLayoutHorizontalFieldKey': 'priority',
+          'matrixLayoutVerticalFieldKey': 'priority',
+          'showTypeIcons': True,
+          'parallelIssueBatches': 4,
+          'issuesPerRow': 5,
+          'secondaryIssues': 1,
+          'boxType': 0
+        }
+
+        diagrams_response = session.post('/rest/dependency-map/1.0/diagram',
+            json=payload)
+        assert diagrams_response.status_code == 200
+        diagramId = diagrams_response.json()['id']
+        diagramKey = str(diagramId)
+
+        saveRemoveDiagramCmd(diagramId)
+
+        #create box colore resource entries.
+        payload = {"diagramId":diagramId,"fieldKey":"priority","fieldOptionId":1,"colorPaletteEntryId":5}
+        diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+            json=payload)
+        assert diagrams_response.status_code == 200
+
+        payload = {"diagramId":diagramId,"fieldKey":"priority","fieldOptionId":2,"colorPaletteEntryId":6}
+        diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+                                     json=payload)
+        assert diagrams_response.status_code == 200
+
+        payload = {"diagramId":diagramId,"fieldKey":"priority","fieldOptionId":3,"colorPaletteEntryId":7}
+        diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+                                 json=payload)
+        assert diagrams_response.status_code == 200
+
+        payload = {"diagramId":diagramId,"fieldKey":"priority","fieldOptionId":4,"colorPaletteEntryId":8}
+        diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+                                 json=payload)
+        assert diagrams_response.status_code == 200
+
+        #Create link config entries
+        # Create linkConfig
+        diagrams_response = session.get('/rest/api/2/issueLinkType')
+        issueLinkTypeId = diagrams_response.json()['issueLinkTypes'][0]['id']
+
+        issueLinkTypeId2 = diagrams_response.json()['issueLinkTypes'][1]['id']
+        issueLinkTypeId3 = diagrams_response.json()['issueLinkTypes'][2]['id']
+
+        payload = { 'diagramId': int(diagramKey), 'linkKey': int(issueLinkTypeId), 'visible': True, 'dashType': 0, 'width': 0, 'colorPaletteEntryId': 20}
+        diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramKey,
+                                         json=payload)
+        assert(diagrams_response.status_code == 200)
+
+        payload = { 'diagramId': int(diagramKey), 'linkKey': int(issueLinkTypeId2), 'visible': True, 'dashType': 0, 'width': 0, 'colorPaletteEntryId': 20}
+        diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramKey,
+                                        json=payload)
+
+        assert(diagrams_response.status_code == 200)
+
+        payload = { 'diagramId': int(diagramKey), 'linkKey': int(issueLinkTypeId3) , 'visible': True, 'dashType': 0, 'width': 0, 'colorPaletteEntryId': 20}
+        diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramKey,
+                                        json=payload)
+        assert(diagrams_response.status_code == 200)

--- a/app/pytests/test_flow_create_issue_link.py
+++ b/app/pytests/test_flow_create_issue_link.py
@@ -1,0 +1,320 @@
+import requests
+from conftest import print_timing_with_additional_arg
+from fixtures import session
+from fixtures import base_url
+import pytest
+from generatetests import pytest_generate_tests
+import os
+from os import path
+import random
+from maxfreq import max_freq
+from conftest import print_in_shell
+from conftest import getRandomProjectId
+from conftest import saveRemoveIssueLinkCmd
+from conftest import getRandomFilter
+
+#POST /rest/api/2/issueLink
+#GET /rest/api/2/issue/10000
+
+_project_id = 0
+
+basepath = path.dirname(__file__)
+out_file_path = path.abspath(path.join(basepath, "deleteCreatedObjects"))
+
+
+@pytest.fixture(scope="class")
+def create_data(session):
+    print_in_shell("Create diagram")
+   # session = requests.session()
+    HOSTNAME = os.environ.get('application_hostname')
+
+    # Get user
+    diagrams_response = session.get('/rest/dependency-map/1.0/user')
+    assert diagrams_response.status_code == 200
+    userKey = diagrams_response.json()["key"]
+    print_in_shell("User key: ", userKey)
+
+    # Get filter key
+    diagrams_response = session.get('/rest/dependency-map/1.0/filter?searchTerm=&page=0&resultsPerPage=25')
+    assert diagrams_response.status_code == 200
+
+    #Get filterKey randomly among the project in the project file
+    filterKey= getRandomFilter(session)
+
+    # Get field status
+    field= 'status'
+
+    # Get project id from the list of projects we shall use, saved in a file
+    projectId=getRandomProjectId()
+
+    # Create diagram
+    payload ={
+      'name':"G100",
+      'layoutId':0,
+      'filterKey': filterKey,
+      'boxColorFieldKey': field,
+      'groupedLayoutFieldKey': field,
+      'matrixLayoutHorizontalFieldKey': 'fixVersions',
+      'matrixLayoutVerticalFieldKey': 'fixVersions',
+      'showTypeIcons': True,
+      'parallelIssueBatches': 4,
+      'issuesPerRow': 5,
+      'secondaryIssues': 1,
+      'boxType': 0
+    }
+    print_in_shell('payload=', payload)
+    diagrams_response = session.post('/rest/dependency-map/1.0/diagram',
+                                     json=payload)
+    assert diagrams_response.status_code == 200
+    diagramId = diagrams_response.json()['id']
+    diagramIdStr = str(diagramId)
+
+
+    #create box colore resource entries.
+    payload = {"diagramId":diagramId,"fieldKey":"status","fieldOptionId":1,"colorPaletteEntryId":5}
+    print_in_shell('payload=', payload)
+
+    diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+                                     json=payload)
+    assert diagrams_response.status_code == 200
+
+    payload = {"diagramId":diagramId,"fieldKey":"status","fieldOptionId":2,"colorPaletteEntryId":6}
+    diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+                                     json=payload)
+    assert diagrams_response.status_code == 200
+
+    payload = {"diagramId":diagramId,"fieldKey":"status","fieldOptionId":3,"colorPaletteEntryId":7}
+    diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+                                     json=payload)
+    assert diagrams_response.status_code == 200
+
+    payload = {"diagramId":diagramId,"fieldKey":"status","fieldOptionId":4,"colorPaletteEntryId":8}
+    diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+                                     json=payload)
+    assert diagrams_response.status_code == 200
+
+    #Create link config entries
+    # Create linkConfig
+    diagrams_response = session.get('/rest/api/2/issueLinkType')
+    issueLinkTypeId = diagrams_response.json()['issueLinkTypes'][0]['id']
+
+    issueLinkTypeId2 = diagrams_response.json()['issueLinkTypes'][1]['id']
+    issueLinkTypeId3 = diagrams_response.json()['issueLinkTypes'][2]['id']
+
+    payload = { 'diagramId': diagramIdStr, 'linkKey': issueLinkTypeId, 'visible': True, 'dashType': 0, 'width': 0, 'colorPaletteEntryId': 20}
+    print_in_shell('payload', payload)
+    diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramKey=' + diagramIdStr,
+                                     json=payload)
+    assert diagrams_response.status_code == 200, diagrams_response.text
+
+    payload = { 'diagramId': diagramIdStr, 'linkKey': issueLinkTypeId2, 'visible': True, 'dashType': 0, 'width': 0, 'colorPaletteEntryId': 21}
+    diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramIdStr,
+                                     json=payload)
+    assert diagrams_response.status_code == 200, diagrams_response.text
+
+    payload = { 'diagramId': diagramIdStr, 'linkKey': issueLinkTypeId3 , 'visible': True, 'dashType': 0, 'width': 0, 'colorPaletteEntryId': 22}
+    diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramIdStr,
+                                     json=payload)
+    assert diagrams_response.status_code == 200, diagrams_response.text
+
+    yield {'diagramId': diagramIdStr,  'projectId':projectId}
+    # diagrams_response2 = session.delete('/rest/dependency-map/1.0/diagram/' + diagramIdStr)
+    # assert diagrams_response2.status_code == 200
+    # print_in_shell("Deleted diagram id=" + diagramIdStr)
+    #
+    # return {'diagramId': diagramIdStr,  'projectId':projectId}
+
+def get_link_type(session):
+    #JIRA Get list of available link types
+    HOSTNAME = os.environ.get('application_hostname')
+    issueLinkTypeId = 0
+    diagrams_response = session.get('/rest/api/2/issueLinkType')
+    issueLinkTypes = diagrams_response.json()['issueLinkTypes']
+    for linkType in issueLinkTypes:
+        print_in_shell(linkType)
+        if linkType["name"]=="Blocks":
+            issueLinkTypeId=linkType["id"]
+            break
+    print_in_shell(issueLinkTypeId)
+    return issueLinkTypeId
+
+
+class TestCreateLink:
+    @max_freq(500/3600)
+#    @print_timing_with_additional_arg
+    def test_show_diagram_flow_ci(self, base_url, session, create_data):
+        diagramIdStr = create_data['diagramId']
+        projectId = create_data['projectId']
+        HOSTNAME = os.environ.get('application_hostname')
+
+        #Get diagram
+        diagram_ids = []
+        startAt = 0
+        while True:
+            resp =  session.get('/rest/dependency-map/1.0/diagram?searchTerm=&startAt=0&maxResults=50')
+            assert resp.status_code == 200
+            result=resp.json()
+            if startAt >= result['total'] or startAt > 500 or not('values' in result):
+                break
+            diagram_ids.extend(list(map(lambda diagram : diagram['id'], result['values'])))
+            startAt = len(diagram_ids)
+
+        issue_ids = []
+        startAt = 0
+        while True:
+            resp = session.get(f'/rest/api/latest/search?maxResults=50&startAt={startAt}&jql=project={projectId}&fields=key')
+            assert resp.status_code == 200
+            result = resp.json()
+            if startAt >= result['total'] or startAt > 500 or not('issues' in result):
+                break
+            issue_ids.extend(list(map(lambda issue : issue['id'], result['issues'])))
+            startAt = len(issue_ids)
+           # print_in_shell(startAt)
+        print_in_shell(issue_ids)
+
+
+
+        #JIRA Get project with everything in it
+        diagrams_response = session.get('/rest/api/2/search?jql=project+%3D+' + '10000' + '+ORDER+BY+Rank+ASC&startAt=0&maxResults=50')
+        assert diagrams_response.status_code == 200
+        #print_in_shell(diagrams_response.json());
+
+        # Get field options - status
+        diagrams_response = session.get('/rest/dependency-map/1.0/fieldOption/status')
+        assert diagrams_response.status_code == 200
+
+        # Get field options - fixVersions
+        diagrams_response = session.get('/rest/dependency-map/1.0/fieldOption/fixVersions')
+        assert diagrams_response.status_code == 200
+
+        #Get color palet entries
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry')
+        assert diagrams_response.status_code == 200
+
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '3')
+        assert diagrams_response.status_code == 200
+        #colorPaletteEntryId =  diagrams_response.json() [-1]["id"]
+        #    print_in_shell("colorPaletteEntryId=" + str(colorPaletteEntryId))
+
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '1')
+        assert diagrams_response.status_code == 200
+
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '4')
+        assert diagrams_response.status_code == 200
+
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '5')
+        assert diagrams_response.status_code == 200
+
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '6')
+        assert diagrams_response.status_code == 200
+
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '-1')
+        assert diagrams_response.status_code == 200
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '10002')
+        assert diagrams_response.status_code == 200
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '10000')
+        assert diagrams_response.status_code == 200
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '10001')
+        assert diagrams_response.status_code == 200
+        #Get color palet entrie
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?palettId=' + '10003')
+        assert diagrams_response.status_code == 200
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramIdStr)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramIdStr)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramIdStr)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramIdStr)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramIdStr)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramIdStr)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+
+        #JIRA Get list of available fileds
+        diagrams_response = session.get('/rest/api/2/field')
+        assert diagrams_response.status_code == 200
+
+        #JIRA Get list of available link types
+        diagrams_response = session.get('/rest/api/2/issueLinkType')
+        assert diagrams_response.status_code == 200
+        issueLinkTypeId = diagrams_response.json()['issueLinkTypes'][0]['id']
+
+        #Get all link configs
+        diagrams_response = session.get('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramIdStr)
+
+    @max_freq(500/3600)
+    @print_timing_with_additional_arg
+    def test_create_issue_link_flow_ci(self, base_url, session, create_data):
+        projectId = create_data['projectId']
+      #  print_in_shell("projectId=" + projectId )
+
+            #JIRA Get list of available issues
+        diagrams_response = session.get('/rest/api/2/search?jql=project=' + projectId)
+        if len(diagrams_response.json()['issues']) > 9:
+            assert diagrams_response.status_code == 200
+            to_issue_id = diagrams_response.json()['issues'][0]['id']
+            to_issue_Key = diagrams_response.json()['issues'][0]['key']
+            from_issue_id = diagrams_response.json()['issues'][9]['id']
+            from_issue_Key = diagrams_response.json()['issues'][9]['key']
+
+            #JIRA Get list of available link types
+            issueLinkTypeId = get_link_type(session)
+
+            #before
+            diagrams_response = session.get('/rest/api/2/issue/' + from_issue_id)
+            before_issue_links = diagrams_response.json()['fields']['issuelinks']
+            before_size = len(before_issue_links)
+
+            #JIRA create link
+            payload = { 'type': { 'id': issueLinkTypeId},
+                        'inwardIssue': { 'id': to_issue_id },
+                        'outwardIssue': { 'id': from_issue_id}}
+            diagrams_response = session.post('/rest/api/2/issueLink',
+                                             json= payload)
+            assert diagrams_response.status_code == 201
+
+            #after
+            diagrams_response = session.get('/rest/api/2/issue/' + from_issue_id)
+            issue_links = diagrams_response.json()['fields']['issuelinks']
+            if (len(issue_links) > before_size):
+                issueLinksId = 0
+                for issueLink in issue_links:
+                   if 'inwardIssue' in issueLink and  issueLink['inwardIssue']:
+                       if  issueLink['inwardIssue']['id']==to_issue_id:
+                           issueLinksId = issueLink['id']
+
+                #issueLinksId = issueLinks[-1]['id']
+                if issueLinksId!=0:
+                   try:
+                       saveRemoveIssueLinkCmd(issueLinksId)
+                   except IOError:
+                       print_in_shell("File not accessible")

--- a/app/pytests/test_flow_show_diagram.py
+++ b/app/pytests/test_flow_show_diagram.py
@@ -1,0 +1,225 @@
+import requests
+import pytest
+import time
+from fixtures import session
+from fixtures import base_url
+import os
+import random
+from maxfreq import max_freq
+from conftest import print_in_shell
+from conftest import print_timing_with_additional_arg
+from conftest import getRandomProjectId
+from conftest import getRandomFilter
+from conftest import saveRemoveDiagramCmd
+
+
+@pytest.fixture(scope="class")
+def create_data(session):
+    # Get user
+    diagrams_response = session.get('/rest/dependency-map/1.0/user')
+    assert diagrams_response.status_code == 200
+    userKey = diagrams_response.json()["key"]
+    print_in_shell("User key: " + userKey)
+
+
+    ##################################################################################################
+    #Create Diagram
+    #################################################################################################
+    # Get filter key
+    diagrams_response = session.get('/rest/dependency-map/1.0/filter?searchTerm=&page=0&resultsPerPage=25')
+    assert diagrams_response.status_code == 200
+
+    #Get filterKey randomly among the project in the project file
+    filterKey= getRandomFilter(session)
+
+    field= 'status'
+    field2='priority'
+
+
+    # Create diagram
+    payload ={
+      'name':"F100",
+      'author':userKey,
+      'lastEditedBy':userKey,
+      'layoutId':2,
+      'filterKey': filterKey,
+      'boxColorFieldKey': field,
+      'groupedLayoutFieldKey': field,
+      'matrixLayoutHorizontalFieldKey': field,
+      'matrixLayoutVerticalFieldKey': field2,
+      'showTypeIcons': True,
+      'parallelIssueBatches': 4,
+      'issuesPerRow': 5,
+      'secondaryIssues': 1,
+      'boxType': 0
+    }
+
+    diagrams_response = session.post('/rest/dependency-map/1.0/diagram',
+        json=payload)
+    assert diagrams_response.status_code == 200
+    diagramId = str(diagrams_response.json()['id'])
+    print_in_shell("Nytt diagram med id="  + diagramId )
+    saveRemoveDiagramCmd(diagramId)
+
+
+    #update box colore resource entry, created if not exists.
+    payload = {"diagramId":diagramId,"fieldKey":"status","fieldOptionId":1,"colorPaletteEntryId":5}
+    diagrams_response = session.post('/rest/dependency-map/1.0/boxColor',
+        json=payload)
+    assert diagrams_response.status_code == 200
+    #print_in_shell( diagrams_response.json() )
+
+    #######################################################
+    # Creae linkConfig
+    #######################################################
+
+    #JIRA Get list of available link types
+    diagrams_response = session.get('/rest/api/2/issueLinkType')
+    issueLinkTypeId = diagrams_response.json()['issueLinkTypes'][0]['id']
+    print_in_shell("issueLinkTypeId=" + issueLinkTypeId)
+
+    # Create linkConfig
+    payload = {
+        'diagramId': int(diagramId),
+        'linkKey': int(issueLinkTypeId),
+        'visible': True,
+        'dashType': 0,
+        'width': 0,
+        'colorPaletteEntryId': 20
+    }
+    print_in_shell('payload', payload)
+
+    diagrams_response = session.post('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramId,
+        json=payload)
+    assert diagrams_response.status_code == 200, diagrams_response.text
+    newLinkConfig = diagrams_response.json()
+    print_in_shell('newLinkConfig', newLinkConfig)
+    #linkConfigId = str(newLinkConfig["id"])
+    #print_in_shell("linkConfigId=" + linkConfigId)
+
+    # yield diagramId
+    #
+    # diagrams_response2 = session.delete('/rest/dependency-map/1.0/diagram/' + diagramId)
+    # assert diagrams_response2.status_code == 200
+    # print_in_shell("Deleted diagram id=" + diagramId)
+
+    return diagramId
+
+
+class TestFlowShowDiagram:
+    @max_freq(1000/3600)
+#    @print_timing_with_additional_arg
+
+    def test_show_diagram_flow_sd(self, base_url, session, create_data):
+        print_in_shell('test_show_diagram_flow_sd start')
+        diagramId=create_data
+        print_in_shell('diagramId', diagramId)
+        #Get all diagrams
+        HOSTNAME = os.environ.get('application_hostname')
+        diagrams_response = session.get('/rest/dependency-map/1.0/diagram?searchTerm=&startAt=0&maxResults=50')
+        assert diagrams_response.status_code == 200, diagrams_response.text
+
+        resp = session.get('/rest/api/latest/project')
+        assert resp.status_code == 200
+        #result = resp.json()
+        #length = len(result)
+        project_id=getRandomProjectId()
+        print_in_shell('project_id', project_id)
+
+        issue_ids = []
+        startAt = 0
+        while True:
+            resp = session.get(f'/rest/api/latest/search?maxResults=50&startAt={startAt}&jql=project={project_id}&fields=key')
+            assert resp.status_code == 200
+            result = resp.json()
+            if startAt >= result['total'] or startAt > 500 or not('issues' in result):
+                break
+            issue_ids.extend(list(map(lambda issue : issue['id'], result['issues'])))
+            startAt = len(issue_ids)
+        print_in_shell(issue_ids)
+
+        #Get color palet entries
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?paletteId=' + '0')
+        assert diagrams_response.status_code == 200
+        colorPaletteEntryId =  diagrams_response.json() [-1]["id"]
+        print_in_shell("colorPaletteEntryId=" + str(colorPaletteEntryId))
+
+        #Get color palet entries
+        diagrams_response = session.get('/rest/dependency-map/1.0/colorPaletteEntry?paletteId=' + '1')
+        assert diagrams_response.status_code == 200
+        colorPaletteEntryId =  diagrams_response.json() [-1]["id"]
+        print_in_shell("colorPaletteEntryId=" + str(colorPaletteEntryId))
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramId)
+        assert diagrams_response.status_code == 200, diagrams_response.text
+        value = diagrams_response.text
+        if not value:
+            print_in_shell( "No response value fieldId 1")
+        else:
+            print_in_shell( diagrams_response.text )
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramId)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+    #    if not value:
+    #        print_in_shell( "No response value fieldId 2")
+    #    else:
+    #       print_in_shell( diagrams_response.json() )
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramId)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+    #    if not value:
+    #        print_in_shell( "No response value fieldId 3")
+    #    else:
+    #        print_in_shell( diagrams_response.json() )
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramId)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+    #    if not value:
+    #        print_in_shell( "No response value fieldId 4")
+    #    else:
+    #        print_in_shell( diagrams_response.json() )
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramId)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+    #    if not value:
+    #        print_in_shell( "No response value fieldId 5")
+    #    else:
+    #        print_in_shell( diagrams_response.json() )
+
+        #Get boxcolor, värden när dessa är explicit ändrade.
+        diagrams_response = session.get('/rest/dependency-map/1.0/boxColor/' + diagramId)
+        assert diagrams_response.status_code == 200
+        value = diagrams_response.text
+    #    if not value:
+    #        print_in_shell( "No response value fieldId -1")
+    #    else:
+    #        print_in_shell( diagrams_response.json() )
+
+        #JIRA Get list of available fileds
+        diagrams_response = session.get('/rest/api/2/field')
+        assert diagrams_response.status_code == 200
+    #    value = diagrams_response.json()[0]
+    #    content = diagrams_response.text
+    #    if not value:
+    #        print_in_shell( "No response value field")
+    #    else:
+    #        print_in_shell(value)
+
+        #JIRA Get list of available link types
+        diagrams_response = session.get('/rest/api/2/issueLinkType')
+        assert diagrams_response.status_code == 200
+        issueLinkTypeId = diagrams_response.json()['issueLinkTypes'][0]['id']
+    #    print_in_shell("issueLinkTypeId=" + issueLinkTypeId)
+
+        #Get all link configs
+        diagrams_response = session.get('/rest/dependency-map/1.0/linkConfig?diagramId=' + diagramId)
+    #    print_in_shell( diagrams_response.json())


### PR DESCRIPTION
As there were test failures when I tried to update our "2021 branch" with the latest from Atlassian (upstream) I now instead pick the pytests stuff for testing DM on to the Atlassian "HEAD".

Have launched testing but as they take a long time, they are not finished yet, thus kind of expecting having to push further updates. To be continue...