### PR TITLE
Fix the regex to extract the pageId from the page source

### DIFF
--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.4.3">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="upload_attachments" enabled="true">
       <stringProp name="TestPlan.comments">This test plan was created by the BlazeMeter converter v.2.4.18. Please contact support@blazemeter.com for further support.</stringProp>
@@ -554,7 +554,7 @@
                 <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="x_editable" enabled="true">
                   <stringProp name="RegexExtractor.useHeaders">false</stringProp>
                   <stringProp name="RegexExtractor.refname">x_editable</stringProp>
-                  <stringProp name="RegexExtractor.regex">id=\&quot;editPageLink\&quot; href=(.+?)\?pageId=(.+?)\&quot;</stringProp>
+                  <stringProp name="RegexExtractor.regex">id=\&quot;editPageLink\&quot;\s+href=(.+?)\?pageId=(.+?)\&quot;</stringProp>
                   <stringProp name="RegexExtractor.template">$1$</stringProp>
                   <stringProp name="RegexExtractor.default"></stringProp>
                   <stringProp name="RegexExtractor.match_number">1</stringProp>
@@ -3446,7 +3446,7 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                 <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="x_editable" enabled="false">
                   <stringProp name="RegexExtractor.useHeaders">false</stringProp>
                   <stringProp name="RegexExtractor.refname">x_editable</stringProp>
-                  <stringProp name="RegexExtractor.regex">id=\&quot;editPageLink\&quot; href=(.+?)\?pageId=(.+?)\&quot;</stringProp>
+                  <stringProp name="RegexExtractor.regex">id=\&quot;editPageLink\&quot;\s+href=(.+?)\?pageId=(.+?)\&quot;</stringProp>
                   <stringProp name="RegexExtractor.template">$1$</stringProp>
                   <stringProp name="RegexExtractor.default"></stringProp>
                   <stringProp name="RegexExtractor.match_number">1</stringProp>
@@ -3560,7 +3560,7 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                 <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="x_editable" enabled="false">
                   <stringProp name="RegexExtractor.useHeaders">false</stringProp>
                   <stringProp name="RegexExtractor.refname">x_editable</stringProp>
-                  <stringProp name="RegexExtractor.regex">id=\&quot;editPageLink\&quot; href=(.+?)\?pageId=(.+?)\&quot;</stringProp>
+                  <stringProp name="RegexExtractor.regex">id=\&quot;editPageLink\&quot;\s+href=(.+?)\?pageId=(.+?)\&quot;</stringProp>
                   <stringProp name="RegexExtractor.template">$1$</stringProp>
                   <stringProp name="RegexExtractor.default"></stringProp>
                   <stringProp name="RegexExtractor.match_number">1</stringProp>


### PR DESCRIPTION
Confluence 8.1 introduced additional whitespace into the HTML tags; we need to change the regular expression extracting the `pageId` to account for it.

**Version 8.0**
```
<a  id="editPageLink" href="/wiki/pages/editpage.action?pageId=1004923276"
```

**Version 8.1**
```
<a  id="editPageLink"                href="/wiki/pages/editpage.action?pageId=1004923276"
```