### PR TITLE
refactor: add logic to not save confluence.page.view to .jtl

### DIFF
--- a/app/selenium_ui/conftest.py
+++ b/app/selenium_ui/conftest.py
@@ -317,7 +317,7 @@ def measure_browser_navi_metrics(webdriver, dataset, expected_metrics):
             if 'page.view' in key:
                 if 'pageID' in post_data_str:
                     page_id = re.search(r'"pageID":"(.+?)"', post_data_str).group(1)
-                    mark = get_mark_from_dataset(page_id, dataset) or f'-create_page'
+                    mark = get_mark_from_dataset(page_id, dataset) or '-create_page'
                 elif 'pageID' in str(requests):
                     page_ids = re.findall(r'"pageID":"(.+?)"', str(requests))
                     print('Cannot find pageID in post data string, searching in request body')

--- a/app/selenium_ui/conftest.py
+++ b/app/selenium_ui/conftest.py
@@ -8,6 +8,7 @@ import sys
 import time
 from datetime import timezone
 import re
+from pprint import pprint
 
 import filelock
 import pytest
@@ -285,50 +286,68 @@ def measure_dom_requests(webdriver, interaction, description=''):
             jtl_file.write(f"{timestamp},{timing},{interaction},,{error_msg},,{success},0,0,0,0,,0\n")
 
 
+def get_mark_from_dataset(page_id: str, dataset: dict) -> str:
+    for name, value in dataset.items():
+        if not value:
+            continue
+        if page_id != value[0]:  # [page_id, project_id, template_id]
+            continue
+        return f'-{name}-{value[2]}'
+    return ''
+
+
 def measure_browser_navi_metrics(webdriver, dataset, expected_metrics):
     requests = get_wait_browser_metrics(webdriver, expected_metrics)
     metrics = []
     for request_id, request in requests.items():
-        if 'browser.metrics.navigation' in str(request):
-            post_data_str = request[0]['params']['request']['postData']
-            post_data = eval(post_data_str.replace('true', 'True').replace('false', 'False'))
-            for data in post_data:
-                if data['name'] == 'browser.metrics.navigation':
-                    key = data['properties']['key']
-                    ready_for_user = data['properties']['readyForUser']
-                    mark = ''
-                    if 'blogpost.view' in key:
-                        blogpost_template_id = dataset['view_blog'][2]
-                        mark = f'-view_blog-{blogpost_template_id}'
-                        print(f'BLOGPOST_FOUND {mark}')
-                    if 'page.view' in key:
-                        if 'pageID' in post_data_str:
-                            page_id = re.search('"pageID":"(.+?)"', post_data_str).group(1)
+        if 'browser.metrics.navigation' not in str(request):
+            continue
+        post_data_str = request[0]['params']['request']['postData']
+        post_data = eval(post_data_str.replace('true', 'True').replace('false', 'False'))
+        for data in post_data:
+            if data['name'] != 'browser.metrics.navigation':
+                continue
+            key = data['properties']['key']
+            ready_for_user = data['properties']['readyForUser']
+            mark = ''  # mark = '' for key == [confluence.dashboard.view, confluence.page.create.collaborative.view...]
+            if 'blogpost.view' in key:
+                blogpost_template_id = dataset['view_blog'][2]
+                mark = f'-view_blog-{blogpost_template_id}'
+                print(f'BLOGPOST_FOUND {mark}')
+            if 'page.view' in key:
+                if 'pageID' in post_data_str:
+                    page_id = re.search(r'"pageID":"(.+?)"', post_data_str).group(1)
+                    mark = get_mark_from_dataset(page_id, dataset) or f'-create_page'
+                elif 'pageID' in str(requests):
+                    page_ids = re.findall(r'"pageID":"(.+?)"', str(requests))
+                    print('Cannot find pageID in post data string, searching in request body')
+                    print(f'Available pageID: {page_ids}')
+                    print(f'Trying to retrieve mark related to first page_id {page_ids[0]}')
+                    mark = get_mark_from_dataset(page_ids[0], dataset)
+                if not mark:  # key == page.view and pageID is not related to any template
+                    print(f'Hit {key} without mark, '
+                          f'this action will not be saved into {selenium_results_file.name}\n'
+                          f'Current url: {webdriver.current_url}\nrequests dict:')
+                    pprint(requests)
+                    continue  # to jump to next element in post_data without appending to metrics
 
-                            for name, value in dataset.items():
-                                if value:
-                                    if page_id == value[0]:  # [page_id, project_id, template_id]
-                                        mark = f'-{name}-{value[2]}'
-                                        break
-                                    else:
-                                        mark = f'-create_page'
-
-                    ready_for_user_dict = {'key': f'{key}{mark}', 'ready_for_user': ready_for_user}
-                    metrics.append(ready_for_user_dict)
+            ready_for_user_dict = {'key': f'{key}{mark}', 'ready_for_user': ready_for_user}
+            metrics.append(ready_for_user_dict)
 
     lockfile = f'{selenium_results_file}.lock'
     error_msg = 'Success'
     success = True
-    if metrics:
-        with filelock.SoftFileLock(lockfile):
-            with open(selenium_results_file, "a+") as jtl_file:
-                for metric in metrics:
-                    interaction = metric['key']
-                    ready_for_user_timing = metric['ready_for_user']
-                    timestamp = round(time.time() * 1000)
-                    jtl_file.write(
-                        f"{timestamp},{ready_for_user_timing},{interaction},,{error_msg},,{success},0,0,0,0,,0\n")
-                    print(f"{timestamp},{ready_for_user_timing},{interaction},{error_msg},{success}")
+    if not metrics:
+        return
+    with filelock.SoftFileLock(lockfile):
+        with open(selenium_results_file, "a+") as jtl_file:
+            for metric in metrics:
+                interaction = metric['key']
+                ready_for_user_timing = metric['ready_for_user']
+                timestamp = round(time.time() * 1000)
+                jtl_file.write(
+                    f"{timestamp},{ready_for_user_timing},{interaction},,{error_msg},,{success},0,0,0,0,,0\n")
+                print(f"{timestamp},{ready_for_user_timing},{interaction},{error_msg},{success}")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Right now I am running tests to confirm if my changes will not impact critical browser metrics.