### PR TITLE
[DO NOT MERGE] Bump chromedriver version up to 115

### DIFF
--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -123,7 +123,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "114.0.5735.90" # Supports Chrome version 114. You can refer to http://chromedriver.chromium.org/downloads
+      version: "115.0.5790.102" # Supports Chrome version 115. You can refer to https://googlechromelabs.github.io/chrome-for-testing/
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -90,7 +90,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "114.0.5735.90" # Supports Chrome version 114. You can refer to http://chromedriver.chromium.org/downloads
+      version: "115.0.5790.102" # Supports Chrome version 115. You can refer to https://googlechromelabs.github.io/chrome-for-testing/
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -117,7 +117,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "114.0.5735.90" # Supports Chrome version 114. You can refer to http://chromedriver.chromium.org/downloads
+      version: "115.0.5790.102" # Supports Chrome version 115. You can refer to https://googlechromelabs.github.io/chrome-for-testing/
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -118,7 +118,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "114.0.5735.90" # Supports Chrome version 114. You can refer to http://chromedriver.chromium.org/downloads
+      version: "115.0.5790.102" # Supports Chrome version 115. You can refer to https://googlechromelabs.github.io/chrome-for-testing/
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -170,7 +170,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "114.0.5735.90" # Supports Chrome version 114. You can refer to http://chromedriver.chromium.org/downloads
+      version: "115.0.5790.102" # Supports Chrome version 115. You can refer to https://googlechromelabs.github.io/chrome-for-testing/
 reporting:
   - data-source: sample-labels
     module: junit-xml


### PR DESCRIPTION
[DO NOT MERGE] Bzt is not able to download chromedriver 115 as they do not adapt yet new changes in chromedriver distribution.