### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ packaging==23.1
 prettytable==3.8.0
 bzt==1.16.23
 boto3==1.28.11
+urwid==2.1.2


### PR DESCRIPTION
Fix dependency problems
I've had a lot of problems with just running standard tests on my environment by just installing requirements.txt file. 
Both on Intel Mac/Mac m2 and windows intel, with clean configurations and following your guide every step. Every time it failed.

But by installing urwid in addition, this issue is fixed. 

This is related to this error: ERROR: PaddingError: width value <WrapMode.CLIP: 'clip'> is not one offixed number of columns, 'pack', ('relative', percentage of total width), 'clip'

I hope this can fix the same problems for lots of other people trying to test their applications. 
