### PR TITLE
Use retry lib in cleanup script

### DIFF
--- a/app/util/k8s/terminate_cluster.py
+++ b/app/util/k8s/terminate_cluster.py
@@ -259,6 +259,7 @@ def delete_hosted_zone_record_if_exists(aws_region, cluster_name):
         except Exception as e:
             logging.error(f"Unexpected error occurs: {e}")
 
+
 @retry(Exception, tries=DEFAULT_RETRY_COUNT, delay=DEFAULT_RETRY_DELAY)
 def delete_lb(aws_region, vpc_id):
     elb_client = boto3.client('elb', region_name=aws_region)
@@ -304,7 +305,6 @@ def wait_for_nat_gateway_delete(ec2, nat_gateway_id):
         logging.error(f"NAT gateway with id {nat_gateway_id} was not deleted in {timeout} seconds.")
 
 
-
 @retry(Exception, tries=DEFAULT_RETRY_COUNT, delay=DEFAULT_RETRY_DELAY)
 def delete_nat_gateway(aws_region, vpc_id):
     ec2_client = boto3.client('ec2', region_name=aws_region)
@@ -323,6 +323,7 @@ def delete_nat_gateway(aws_region, vpc_id):
                 wait_for_nat_gateway_delete(ec2_client, nat_gateway_id)
             except Boto3Error as e:
                 logging.error(f"Deleting NAT gateway with id {nat_gateway_id} failed with error: {e}")
+
 
 @retry(Exception, tries=DEFAULT_RETRY_COUNT, delay=DEFAULT_RETRY_DELAY)
 def delete_igw(ec2_resource, vpc_id):
@@ -371,6 +372,7 @@ def delete_subnets(ec2_resource, vpc_id, aws_region):
         except Boto3Error as e:
             logging.error(f"Delete of subnet failed with error: {e}")
 
+
 @retry(Exception, tries=DEFAULT_RETRY_COUNT, delay=DEFAULT_RETRY_DELAY)
 def delete_route_tables(ec2_resource, vpc_id):
     vpc_resource = ec2_resource.Vpc(vpc_id)
@@ -386,6 +388,7 @@ def delete_route_tables(ec2_resource, vpc_id):
                 table.delete()
         except Boto3Error as e:
             logging.error(f"Delete of route table failed with error: {e}")
+
 
 @retry(Exception, tries=DEFAULT_RETRY_COUNT, delay=DEFAULT_RETRY_DELAY)
 def delete_security_groups(ec2_resource, vpc_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ packaging==23.1
 prettytable==3.9.0
 bzt==1.16.26
 boto3==1.28.56
+retry==0.9.2


### PR DESCRIPTION
This will make the cleanup script a bit more reliable, especially when it comes to subnet deletion. By default there are 3 tries with a 10 second timeout, except for subnets because sometimes resources in a terminating state still use subnets (or at least AWS API thinks so). 