### PR TITLE
typos: aws_envs/aws_envs AND scale_profile.yml

### DIFF
--- a/docs/dc-apps-performance-toolkit-user-guide-confluence.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-confluence.md
@@ -384,11 +384,11 @@ This scenario helps to identify basic performance issues without a need to spin 
 To receive performance baseline results **without** an app installed:
 
 1. Before run:
-   * Make sure `jira.yml` and toolkit code base has default configuration from the `master` branch.
+   * Make sure `confluence.yml` and toolkit code base has default configuration from the `master` branch.
    * Check load configuration parameters needed for enterprise-scale run: [Setting up load configuration for Enterprise-scale runs](#loadconfiguration).
    * Check correctness of `application_hostname`, `application_protocol`, `application_port` and `application_postfix` in .yml file.
    * `standalone_extension` set to 0. App-specific actions are not needed for Run1 and Run2.
-   * AWS access keys set in `./dc-app-performance-toolkit/app/util/k8s/aws_envs/aws_envs` file:
+   * AWS access keys set in `./dc-app-performance-toolkit/app/util/k8s/aws_envs` file:
       - `AWS_ACCESS_KEY_ID`
       - `AWS_SECRET_ACCESS_KEY`
       - `AWS_SESSION_TOKEN` (only for temporary creds)
@@ -479,7 +479,7 @@ To receive scalability benchmark results for one-node Confluence DC **with** app
    * Check load configuration parameters needed for enterprise-scale run: [Setting up load configuration for Enterprise-scale runs](#loadconfiguration).
    * `standalone_extension` set to non 0 and .jmx file has standalone actions implementation in case of JMeter app-specific actions.
    * [test_1_selenium_custom_action](https://github.com/atlassian/dc-app-performance-toolkit/blob/master/app/selenium_ui/confluence_ui.py#L47-L48) is uncommented and has implementation in case of Selenium app-specific actions.
-   * AWS access keys set in `./dc-app-performance-toolkit/app/util/k8s/aws_envs/aws_envs` file:
+   * AWS access keys set in `./dc-app-performance-toolkit/app/util/k8s/aws_envs` file:
       - `AWS_ACCESS_KEY_ID`
       - `AWS_SECRET_ACCESS_KEY`
       - `AWS_SESSION_TOKEN` (only for temporary creds)
@@ -573,7 +573,7 @@ Review `results_summary.log` file under artifacts dir location. Make sure that o
 
 To generate a scalability report:
 
-1. Edit the `./app/reports_generation/performance_profile.yml` file:
+1. Edit the `./app/reports_generation/scale_profile.yml` file:
    - For `runName: "1 Node"`, in the `relativePath` key, insert the relative path to results directory of [Run 3](#run3).
    - For `runName: "2 Nodes"`, in the `relativePath` key, insert the relative path to results directory of [Run 4](#run4).
    - For `runName: "4 Nodes"`, in the `relativePath` key, insert the relative path to results directory of [Run 5](#run5).


### PR DESCRIPTION
Dear Team,
some slight "typos" I found in docs/dc-apps-performance-toolkit-user-guide-confluence.md.
cheers
Anton