### PR TITLE
Set min_cluster_capacity to 2

### DIFF
--- a/app/util/k8s/dcapt.tfvars
+++ b/app/util/k8s/dcapt.tfvars
@@ -65,7 +65,7 @@ instance_disk_size = 200
 # Cluster-autoscaler is installed in the EKS cluster that will manage the requested capacity
 # and increase/decrease the number of nodes accordingly. This ensures there is always enough resources for the workloads
 # and removes the need to change this value.
-min_cluster_capacity = 1
+min_cluster_capacity = 2
 max_cluster_capacity = 6
 
 # By default, Ingress controller listens on 443 and 80. You can enable only http port 80 by


### PR DESCRIPTION
1 product pod and exec env pod require at least 2 instances.
So having min_cluster capacity as 2 will speedup deployment.