### PR TITLE
Issue/confsrvdev 29974 add xsrf token to some actions

### DIFF
--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -860,7 +860,7 @@ log.info(&quot;Confluence version: ${confluence-version}&quot;)</stringProp>
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -1353,7 +1353,7 @@ if ( sleep_time &gt; 0 ) {
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -1657,7 +1657,7 @@ if ( sleep_time &gt; 0 ) {
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -2161,7 +2161,7 @@ if ( sleep_time &gt; 0 ) {
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -2295,7 +2295,7 @@ if ( sleep_time &gt; 0 ) {
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -2834,7 +2834,7 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -3344,7 +3344,7 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -3719,7 +3719,7 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -4414,7 +4414,7 @@ if ( sleep_time &gt; 0 ) {
                     </elementProp>
                     <elementProp name="atl_token" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.value">${atlassian-token}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                       <stringProp name="Argument.name">atl_token</stringProp>
@@ -4893,7 +4893,7 @@ if ( sleep_time &gt; 0 ) {
                       </elementProp>
                       <elementProp name="atl_token" elementType="HTTPArgument">
                         <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                        <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                        <stringProp name="Argument.value">${atlassian-token}</stringProp>
                         <stringProp name="Argument.metadata">=</stringProp>
                         <boolProp name="HTTPArgument.use_equals">true</boolProp>
                         <stringProp name="Argument.name">atl_token</stringProp>

--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -858,6 +858,13 @@ log.info(&quot;Confluence version: ${confluence-version}&quot;)</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
+                    </elementProp>
                   </collectionProp>
                 </elementProp>
                 <stringProp name="HTTPSampler.domain"></stringProp>
@@ -1344,6 +1351,13 @@ if ( sleep_time &gt; 0 ) {
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
+                    </elementProp>
                   </collectionProp>
                 </elementProp>
                 <stringProp name="HTTPSampler.domain"></stringProp>
@@ -1640,6 +1654,13 @@ if ( sleep_time &gt; 0 ) {
                       <stringProp name="Argument.value">${blog_space_key}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                    </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
@@ -2137,6 +2158,13 @@ if ( sleep_time &gt; 0 ) {
                       <stringProp name="Argument.value">${__time(,)}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                    </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
@@ -2797,6 +2825,13 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
+                    </elementProp>
                   </collectionProp>
                 </elementProp>
                 <stringProp name="HTTPSampler.domain"></stringProp>
@@ -3300,6 +3335,13 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
+                    </elementProp>
                   </collectionProp>
                 </elementProp>
                 <stringProp name="HTTPSampler.domain"></stringProp>
@@ -3667,6 +3709,13 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                       <stringProp name="Argument.value">${__time(,)}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                    </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
@@ -4356,6 +4405,13 @@ if ( sleep_time &gt; 0 ) {
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
+                    </elementProp>
                   </collectionProp>
                 </elementProp>
                 <stringProp name="HTTPSampler.domain"></stringProp>
@@ -4827,6 +4883,13 @@ if ( sleep_time &gt; 0 ) {
                         <stringProp name="Argument.value">${__time(,)}</stringProp>
                         <stringProp name="Argument.metadata">=</stringProp>
                         <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      </elementProp>
+                      <elementProp name="atl_token" elementType="HTTPArgument">
+                        <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                        <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                        <stringProp name="Argument.metadata">=</stringProp>
+                        <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                        <stringProp name="Argument.name">atl_token</stringProp>
                       </elementProp>
                     </collectionProp>
                   </elementProp>

--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -2293,6 +2293,13 @@ if ( sleep_time &gt; 0 ) {
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>
+                    <elementProp name="atl_token" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">${ajs-atl-token}</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">atl_token</stringProp>
+                    </elementProp>
                   </collectionProp>
                 </elementProp>
                 <stringProp name="HTTPSampler.domain"></stringProp>

--- a/app/locustio/confluence/http_actions.py
+++ b/app/locustio/confluence/http_actions.py
@@ -755,6 +755,7 @@ def create_and_edit_page(locust):
         r = locust.get(f'/pages/createpage.action'
                        f'?spaceKey={space_key}'
                        f'&fromPageId={page_id}'
+                       f"&atl_token={locust.session_data_storage['token']}"
                        f'&src=quick-create',
                        catch_response=True)
 

--- a/app/locustio/confluence/http_actions.py
+++ b/app/locustio/confluence/http_actions.py
@@ -455,8 +455,8 @@ def open_editor_and_create_blog(locust):
 
         # 550 pages/createblogpost.action
         r = locust.get(f'/pages/createblogpost.action'
-                       #f"&atl_token={locust.session_data_storage['token']}"
-                       f'?spaceKey={blog_space_key}',
+                       f'?spaceKey={blog_space_key}'
+                       f"&atl_token={locust.session_data_storage['token']}",
                        catch_response=True)
 
         content = r.content.decode('utf-8')

--- a/app/locustio/confluence/http_actions.py
+++ b/app/locustio/confluence/http_actions.py
@@ -205,6 +205,7 @@ def view_page(locust):
                f'&pageId={parsed_page_id}'
                f'&spaceKey={space_key}'
                f'&atl_after_login_redirect=/pages/viewpage.action'
+               f"&atl_token={locust.session_data_storage['token']}"
                f'&timeout=12000&_={timestamp_int()}',
                catch_response=True)
 
@@ -385,6 +386,7 @@ def view_blog(locust):
                    f'&pageId={blog_id}'
                    f'&spaceKey={space_key}'
                    f'&atl_after_login_redirect=/pages/viewpage.action'
+                   f"&atl_token={locust.session_data_storage['token']}"
                    f'&timeout=12000&_={timestamp_int()}',
                    catch_response=True)
 
@@ -453,6 +455,7 @@ def open_editor_and_create_blog(locust):
 
         # 550 pages/createblogpost.action
         r = locust.get(f'/pages/createblogpost.action'
+                       f"&atl_token={locust.session_data_storage['token']}"
                        f'?spaceKey={blog_space_key}',
                        catch_response=True)
 
@@ -711,6 +714,7 @@ def open_editor_and_create_blog(locust):
                        f'&pageId={content_id}'
                        f'&spaceKey={parsed_space_key}'
                        f'&atl_after_login_redirect=/pages/viewpage.action'
+                       f"&atl_token={locust.session_data_storage['token']}"
                        f'&timeout=12000&_={timestamp_int()}',
                        catch_response=True)
 
@@ -1023,6 +1027,7 @@ def create_and_edit_page(locust):
                        f'&pageId={locust.session_data_storage["content_id"]}'
                        f'&spaceKey={space_key}'
                        f'&atl_after_login_redirect=/display/{space_key}/{page_title}'
+                       f"&atl_token={locust.session_data_storage['token']}"
                        f'&timeout=12000&_={timestamp_int()}',
                        catch_response=True)
 
@@ -1279,6 +1284,7 @@ def create_and_edit_page(locust):
                    f'&pageId={locust.session_data_storage["content_id"]}'
                    f'&spaceKey={space_key}'
                    f'&atl_after_login_redirect=/pages/viewpage.action'
+                   f"&atl_token={locust.session_data_storage['token']}"
                    f'&timeout=12000'
                    f'&_={timestamp_int()}', catch_response=True)
 
@@ -1441,6 +1447,7 @@ def view_attachments(locust):
                f'&pageId={page_id}'
                f'&spaceKey={space_key}'
                f'&atl_after_login_redirect=/pages/viewpage.action'
+               f"&atl_token={locust.session_data_storage['token']}"
                f'&timeout=12000'
                f'&_={timestamp_int()}',
                catch_response=True)
@@ -1555,6 +1562,7 @@ def upload_attachments(locust):
                f'&pageId={page_id}'
                f'&spaceKey={space_key}'
                f'&atl_after_login_redirect=/pages/viewpage.action'
+               f"&atl_token={locust.session_data_storage['token']}"
                f'&timeout=12000'
                f'&_={timestamp_int()}',
                catch_response=True)

--- a/app/locustio/confluence/http_actions.py
+++ b/app/locustio/confluence/http_actions.py
@@ -455,7 +455,7 @@ def open_editor_and_create_blog(locust):
 
         # 550 pages/createblogpost.action
         r = locust.get(f'/pages/createblogpost.action'
-                       f"&atl_token={locust.session_data_storage['token']}"
+                       #f"&atl_token={locust.session_data_storage['token']}"
                        f'?spaceKey={blog_space_key}',
                        catch_response=True)
 

--- a/app/selenium_ui/confluence/pages/pages.py
+++ b/app/selenium_ui/confluence/pages/pages.py
@@ -3,7 +3,7 @@ import time
 from selenium_ui.base_page import BasePage
 
 from selenium_ui.confluence.pages.selectors import UrlManager, LoginPageLocators, AllUpdatesLocators, PopupLocators,\
-    PageLocators, DashboardLocators, TopPanelLocators, EditorLocators, LogoutLocators
+    PageLocators, DashboardLocators, TopPanelLocators, EditorLocators, LogoutLocators, XsrfTokenLocators
 
 
 class Login(BasePage):
@@ -118,7 +118,9 @@ class Editor(BasePage):
     def __init__(self, driver, page_id=None):
         BasePage.__init__(self, driver)
         url_manager = UrlManager(page_id=page_id)
-        self.page_url = url_manager.edit_page_url()
+
+        xsrf_token = self.get_element(XsrfTokenLocators.xsrf_token).get_attribute('content')
+        self.page_url = url_manager.edit_page_url() + "&atl_token=" + xsrf_token
 
     def wait_for_create_page_open(self):
         self.wait_until_clickable(EditorLocators.publish_button)

--- a/app/selenium_ui/confluence/pages/selectors.py
+++ b/app/selenium_ui/confluence/pages/selectors.py
@@ -94,5 +94,6 @@ class EditorLocators:
 class LogoutLocators:
     logout_msg = (By.ID, "logout-message")
 
+
 class XsrfTokenLocators:
     xsrf_token = (By.ID, "atlassian-token")

--- a/app/selenium_ui/confluence/pages/selectors.py
+++ b/app/selenium_ui/confluence/pages/selectors.py
@@ -93,3 +93,6 @@ class EditorLocators:
 
 class LogoutLocators:
     logout_msg = (By.ID, "logout-message")
+
+class XsrfTokenLocators:
+    xsrf_token = (By.ID, "atlassian-token")


### PR DESCRIPTION
in the recent Confluence Struts XSRF ON project for Conf 8.9 and later, we update several APIs (GET) to require a XSRF token in the request. So the related API calls need to be updated in this repo with an extra query parameter `atl_token`. 

As it is just an extra query parameter, so the changes are backward compatible, as Conf 7.19 and 8.5 will just ignore it.


***Custom Build [PASSED]***

build Url: [Confluence Performance DC Apps Dev #560](https://server-syd-bamboo.internal.atlassian.com/browse/CONFA1PW-CEDCAPPSDEV)
run branch: [issue/CONFSRVDEV-29974-add-xsrf-token-to-edit-page-action](https://github.com/atlassian/dc-app-performance-toolkit/tree/issue/CONFSRVDEV-29974-add-xsrf-token-to-edit-page-action)

***Build Snapshot***

![image](https://github.com/atlassian/dc-app-performance-toolkit/assets/117452202/4b94dd5c-2866-43d2-9a1c-291f1e608246)
![image](https://github.com/atlassian/dc-app-performance-toolkit/assets/117452202/56cb84d9-1162-433f-b457-17a94d1a0a7b)

***Why Upload Analytics to Data lake [FAILED]***

Because the key `home_shared_write_latency_value_confa1pw_cedcappsdev` does not exists for [Confluence Performance DC Apps Dev](https://server-syd-bamboo.internal.atlassian.com/browse/CONFA1PW-CEDCAPPSDEV). We only have `home_local_write_latency_synthetic_statistics_confa1pw_cedcapt` which is for [Confluence Performance DC Apps](https://server-syd-bamboo.internal.atlassian.com/browse/CONFA1PW-CEDCAPT)

I think this is a known and existing issue for dev build? e.g. [Confluence Performance DC Apps Dev #549](https://server-syd-bamboo.internal.atlassian.com/browse/CONFA1PW-CEDCAPPSDEV)

![image](https://github.com/atlassian/dc-app-performance-toolkit/assets/117452202/17a2d889-c6a8-44db-a2aa-579be8ed7331)



