### PR TITLE
Release 8.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM python:3.11-slim-bullseye
 
 ENV APT_INSTALL="apt-get -y install --no-install-recommends"
 
-ARG CHROME_VERSION="123.0.6312.122-1"
+ARG CHROME_VERSION="latest"
 
 ENV CHROME_LATEST_URL="https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
 ENV CHROME_VERSION_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb"

--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -20,7 +20,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.5
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     # Action percentage for JMeter load executor
     view_all_builds: 15

--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -125,7 +125,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "123.0.6312.122" # Supports Chrome version 123. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "124.0.6367.60" # Supports Chrome version 124. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -20,7 +20,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.5
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
 services:
   - module: shellexec

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -91,7 +91,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "123.0.6312.122" # Supports Chrome version 123. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "124.0.6367.60" # Supports Chrome version 124. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -118,7 +118,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "123.0.6312.122" # Supports Chrome version 123. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "124.0.6367.60" # Supports Chrome version 124. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -20,7 +20,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.5
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     extended_metrics: False
     # Action percentage for JMeter and Locust load executors

--- a/app/crowd.yml
+++ b/app/crowd.yml
@@ -32,7 +32,7 @@ settings:
 
     JMETER_VERSION: 5.5
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
 services:
   - module: shellexec

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -119,7 +119,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "123.0.6312.122" # Supports Chrome version 123. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "124.0.6367.60" # Supports Chrome version 124. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -20,7 +20,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.5
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     # Action percentage for Jmeter and Locust load executors
     create_issue: 4

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -23,7 +23,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.5
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     # Action percentage for Jmeter and Locust load executors
     agent_browse_projects: 10

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -171,7 +171,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "123.0.6312.122" # Supports Chrome version 123. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "124.0.6367.60" # Supports Chrome version 124. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
   - data-source: sample-labels
     module: junit-xml

--- a/app/util/conf.py
+++ b/app/util/conf.py
@@ -2,8 +2,8 @@ import yaml
 
 from util.project_paths import JIRA_YML, CONFLUENCE_YML, BITBUCKET_YML, JSM_YML, CROWD_YML, BAMBOO_YML
 
-TOOLKIT_VERSION = '8.3.0'
-UNSUPPORTED_VERSION = '7.6.0'
+TOOLKIT_VERSION = '8.2.1'
+UNSUPPORTED_VERSION = '7.5.0'
 
 
 def read_yml_file(file):

--- a/app/util/conf.py
+++ b/app/util/conf.py
@@ -2,8 +2,8 @@ import yaml
 
 from util.project_paths import JIRA_YML, CONFLUENCE_YML, BITBUCKET_YML, JSM_YML, CROWD_YML, BAMBOO_YML
 
-TOOLKIT_VERSION = '8.2.0'
-UNSUPPORTED_VERSION = '7.5.0'
+TOOLKIT_VERSION = '8.3.0'
+UNSUPPORTED_VERSION = '7.6.0'
 
 
 def read_yml_file(file):

--- a/app/util/k8s/README.MD
+++ b/app/util/k8s/README.MD
@@ -30,7 +30,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+-it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
 ```
 ### Terminate development environment
 Note: install and uninstall commands have to use the same `atlassianlabs/terraform:TAG` image tag.
@@ -42,7 +42,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.7.7 ./uninstall.sh -c conf.tfvars
+-it atlassianlabs/terraform:2.7.9 ./uninstall.sh -c conf.tfvars
 ```
 
 # Enterprise-scale environment
@@ -59,7 +59,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+-it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
 ```
 ### Terminate enterprise-scale environment
 Note: install and uninstall commands have to use the same `atlassianlabs/terraform:TAG` image tag.
@@ -71,7 +71,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.7.7 ./uninstall.sh -c conf.tfvars
+-it atlassianlabs/terraform:2.7.9 ./uninstall.sh -c conf.tfvars
 ```
 
 # Collect detailed k8s logs
@@ -91,7 +91,7 @@ export REGION=us-east-2
 docker run --pull=always --env-file aws_envs \
 -v "/$PWD/k8s_logs:/data-center-terraform/k8s_logs" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.7.7 ./scripts/collect_k8s_logs.sh atlas-$ENVIRONMENT_NAME-cluster $REGION k8s_logs
+-it atlassianlabs/terraform:2.7.9 ./scripts/collect_k8s_logs.sh atlas-$ENVIRONMENT_NAME-cluster $REGION k8s_logs
 ```
 
 # Force terminate cluster
@@ -124,7 +124,7 @@ atlassian/dcapt terminate_cluster.py --cluster_name atlas-$ENVIRONMENT_NAME-clus
     docker run --pull=always --env-file aws_envs \
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -e REGION=$REGION \
-    -it atlassianlabs/terraform:2.7.7 bash 
+    -it atlassianlabs/terraform:2.7.9 bash 
     ```
 
 5. Connect to the product pod. Example below for jira pod with number 0. For other product or pod number change `PRODUCT_POD` accordingly.
@@ -148,7 +148,7 @@ atlassian/dcapt terminate_cluster.py --cluster_name atlas-$ENVIRONMENT_NAME-clus
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -e REGION=$REGION \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
-    -it atlassianlabs/terraform:2.7.7 bash 
+    -it atlassianlabs/terraform:2.7.9 bash 
     ```
 5. Copy code base and connect to the execution environment pod:
     ``` bash
@@ -176,7 +176,7 @@ atlassian/dcapt terminate_cluster.py --cluster_name atlas-$ENVIRONMENT_NAME-clus
     -e REGION=$REGION \
     -e PRODUCT=$PRODUCT \
     -v "/$PWD/script-runner.yml:/data-center-terraform/script-runner.yml" \
-    -it atlassianlabs/terraform:2.7.7 bash 
+    -it atlassianlabs/terraform:2.7.9 bash 
     ```
 5. Run following commands one by one inside docker container:
     ``` bash
@@ -204,7 +204,7 @@ To enable detailed CPU/Memory monitoring and Grafana dashboards for visualisatio
     docker run --pull=always --env-file aws_envs \
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -e REGION=$REGION \
-    -it atlassianlabs/terraform:2.7.7 bash 
+    -it atlassianlabs/terraform:2.7.9 bash 
     ```
     ``` bash
     aws eks update-kubeconfig --name atlas-$ENVIRONMENT_NAME-cluster --region $REGION
@@ -240,5 +240,5 @@ Note: this option is **not** suitable for full-scale performance runs as local n
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jira.yml
     ```

--- a/docs/dc-apps-performance-toolkit-user-guide-bamboo.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-bamboo.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2024-03-19"
+date: "2024-04-29"
 ---
 # Data Center App Performance Toolkit User Guide For Bamboo
 
@@ -71,7 +71,7 @@ specifically for performance testing during the DC app review process.
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 7. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/bamboo`.
 8. Wait for all remote agents to be started and connected. It can take up to 10 minutes. Agents can be checked in `Settings` > `Agents`.
@@ -272,7 +272,7 @@ To receive performance baseline results **without** an app installed and **witho
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh bamboo.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh bamboo.yml
     ```
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/bamboo/YY-MM-DD-hh-mm-ss` folder:
     - `results_summary.log`: detailed run summary
@@ -303,7 +303,7 @@ To receive performance results with an app installed (still use master branch):
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh bamboo.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh bamboo.yml
     ```
 
 {{% note %}}
@@ -337,7 +337,7 @@ To receive results for Bamboo DC **with app** and **with app-specific actions**:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh bamboo.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh bamboo.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-bitbucket.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-bitbucket.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2024-03-19"
+date: "2024-04-29"
 ---
 # Data Center App Performance Toolkit User Guide For Bitbucket
 
@@ -84,7 +84,7 @@ Below process describes how to install low-tier Bitbucket DC with "small" datase
    -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/bitbucket`.
 
@@ -248,7 +248,7 @@ Below process describes how to install enterprise-scale Bitbucket DC with "large
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/bitbucket`.
 
@@ -323,7 +323,7 @@ To receive performance baseline results **without** an app installed:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh bitbucket.yml
     ```
 
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/bitbucket/YY-MM-DD-hh-mm-ss` folder:
@@ -354,7 +354,7 @@ To receive performance results with an app installed (still use master branch):
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh bitbucket.yml
     ```
 
 {{% note %}}
@@ -404,7 +404,7 @@ To receive scalability benchmark results for one-node Bitbucket DC **with** app-
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh bitbucket.yml
     ```
    
 {{% note %}}
@@ -429,7 +429,7 @@ To receive scalability benchmark results for two-node Bitbucket DC **with** app-
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 1. Navigate to `dc-app-performance-toolkit` folder and start tests execution:
     ``` bash
@@ -442,7 +442,7 @@ To receive scalability benchmark results for two-node Bitbucket DC **with** app-
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh bitbucket.yml
     ```
 
 {{% note %}}
@@ -471,7 +471,7 @@ To receive scalability benchmark results for four-node Bitbucket DC with app-spe
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh bitbucket.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-confluence.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-confluence.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2024-03-19"
+date: "2024-04-29"
 ---
 # Data Center App Performance Toolkit User Guide For Confluence
 
@@ -83,7 +83,7 @@ Below process describes how to install low-tier Confluence DC with "small" datas
    -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/confluence`.
 
@@ -328,7 +328,7 @@ Below process describes how to install enterprise-scale Confluence DC with "larg
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/confluence`.
 
@@ -403,7 +403,7 @@ To receive performance baseline results **without** an app installed:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh confluence.yml
     ```
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/confluence/YY-MM-DD-hh-mm-ss` folder:
     - `results_summary.log`: detailed run summary
@@ -433,7 +433,7 @@ To receive performance results with an app installed (still use master branch):
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh confluence.yml
     ```
 
 {{% note %}}
@@ -494,7 +494,7 @@ To receive scalability benchmark results for one-node Confluence DC **with** app
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh confluence.yml
     ```
 
 {{% note %}}
@@ -519,7 +519,7 @@ To receive scalability benchmark results for two-node Confluence DC **with** app
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 1. Navigate to `dc-app-performance-toolkit` folder and start tests execution:
     ``` bash
@@ -532,7 +532,7 @@ To receive scalability benchmark results for two-node Confluence DC **with** app
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh confluence.yml
     ```
 
 {{% note %}}
@@ -561,7 +561,7 @@ To receive scalability benchmark results for four-node Confluence DC with app-sp
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh confluence.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-crowd.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-crowd.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2024-03-19"
+date: "2024-04-29"
 ---
 # Data Center App Performance Toolkit User Guide For Crowd
 
@@ -66,7 +66,7 @@ specifically for performance testing during the DC app review process.
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 7. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/crowd`.
 
@@ -177,7 +177,7 @@ To receive performance baseline results **without** an app installed and **witho
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh crowd.yml
     ```
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/crowd/YY-MM-DD-hh-mm-ss` folder:
     - `results_summary.log`: detailed run summary
@@ -206,7 +206,7 @@ To receive performance results with an app installed (still use master branch):
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh crowd.yml
     ```
 
 {{% note %}}
@@ -265,7 +265,7 @@ To receive scalability benchmark results for one-node Crowd DC **with** app-spec
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh crowd.yml
     ```
 
 {{% note %}}
@@ -289,7 +289,7 @@ To receive scalability benchmark results for two-node Crowd DC **with** app-spec
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 1. Edit **run parameters** for 2 nodes run. To do it, left uncommented only 2 nodes scenario parameters in `crowd.yml` file.
    ```
@@ -316,7 +316,7 @@ To receive scalability benchmark results for two-node Crowd DC **with** app-spec
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh crowd.yml
     ```
 
 {{% note %}}
@@ -359,7 +359,7 @@ To receive scalability benchmark results for four-node Crowd DC with app-specifi
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh crowd.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-jira.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-jira.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2024-03-19"
+date: "2024-04-29"
 ---
 # Data Center App Performance Toolkit User Guide For Jira
 
@@ -95,7 +95,7 @@ Below process describes how to install low-tier Jira DC with "small" dataset inc
    -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/jira`.
@@ -356,7 +356,7 @@ Below process describes how to install enterprise-scale Jira DC with "large" dat
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/jira`.
 
@@ -431,7 +431,7 @@ To receive performance baseline results **without** an app installed:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jira.yml
     ```
 1. View the results files of the run in the local `dc-app-performance-toolkit/app/results/jira/YY-MM-DD-hh-mm-ss` folder:
     - `results_summary.log`: detailed run summary
@@ -483,7 +483,7 @@ Re-index information window is displayed on the **Indexing page**. If the window
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jira.yml
     ```
 
 {{% note %}}
@@ -544,7 +544,7 @@ To receive scalability benchmark results for one-node Jira DC **with** app-speci
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jira.yml
     ```
 
 {{% note %}}
@@ -569,7 +569,7 @@ To receive scalability benchmark results for two-node Jira DC **with** app-speci
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 1. Navigate to `dc-app-performance-toolkit` folder and start tests execution:
     ``` bash
@@ -582,7 +582,7 @@ To receive scalability benchmark results for two-node Jira DC **with** app-speci
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jira.yml
     ```
 
 {{% note %}}
@@ -611,7 +611,7 @@ To receive scalability benchmark results for four-node Jira DC with app-specific
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jira.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-jsm.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-jsm.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2024-03-19"
+date: "2024-04-29"
 ---
 # Data Center App Performance Toolkit User Guide For Jira Service Management
 
@@ -97,7 +97,7 @@ Below process describes how to install low-tier Jira Service Management DC with 
    -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/jira`.
 
@@ -392,7 +392,7 @@ Below process describes how to install enterprise-scale Jira Service Management 
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/jira`.
 
@@ -472,7 +472,7 @@ To receive performance baseline results **without** an app installed:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jsm.yml
     ```
 
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/jsm/YY-MM-DD-hh-mm-ss` folder:
@@ -527,7 +527,7 @@ Re-index information window is displayed on the **Indexing page**. If the window
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jsm.yml
     ```
 
 {{% note %}}
@@ -587,7 +587,7 @@ To receive scalability benchmark results for one-node Jira Service Management DC
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jsm.yml
     ```
 
 {{% note %}}
@@ -612,7 +612,7 @@ To receive scalability benchmark results for two-node Jira Service Management DC
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.7.7 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.7.9 ./install.sh -c conf.tfvars
    ```
 1. Navigate to `dc-app-performance-toolkit` folder and start tests execution:
     ``` bash
@@ -625,7 +625,7 @@ To receive scalability benchmark results for two-node Jira Service Management DC
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jsm.yml
     ```
 
 {{% note %}}
@@ -654,7 +654,7 @@ To receive scalability benchmark results for four-node Jira Service Management D
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.7.7 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.7.9 bash bzt_on_pod.sh jsm.yml
     ```
    
 {{% note %}}


### PR DESCRIPTION
## Changed
- Bump TerraForm docker image tag to `atlassianlabs/terraform:2.7.9` to fix MIME type deployment issue

## Upgrade instructions
- `git pull` from `master` branch
- activate virtual env for the toolkit (see README.md for details)
- `pip install -r requirements.txt`

## Important
Use the same `atlassianlabs/terraform` image tag to deploy, upgrade, and undeploy the environment.