### PR TITLE
CONFSRVDEV-33309: Modify confluence.jmx to avoid unnecessary URL redirection when visiting a page or blog post

### DIFF
--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -67,7 +67,7 @@
         </collectionProp>
       </HeaderManager>
       <hashTree/>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Confluence" enabled="true">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Confluence">
         <intProp name="ThreadGroup.num_threads">1</intProp>
         <intProp name="ThreadGroup.ramp_time">0</intProp>
         <longProp name="ThreadGroup.duration">3600</longProp>
@@ -2365,14 +2365,14 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                 </JSR223PreProcessor>
                 <hashTree/>
               </hashTree>
-              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901">
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901" enabled="true">
                 <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &lt; 901)}</stringProp>
                 <boolProp name="IfController.evaluateAll">false</boolProp>
                 <boolProp name="IfController.useExpression">true</boolProp>
               </IfController>
               <hashTree>
-                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="260 /display/${space_key}/${page_title}" enabled="true">
-                  <stringProp name="HTTPSampler.path">${application.postfix}/display/${space_key}/pages/${page_title}</stringProp>
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="260 /display/${space_key}/${page_title}">
+                  <stringProp name="HTTPSampler.path">${application.postfix}/display/${space_key}/${page_title}</stringProp>
                   <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                   <stringProp name="HTTPSampler.method">GET</stringProp>
                   <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
@@ -2403,7 +2403,7 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                 <boolProp name="IfController.useExpression">true</boolProp>
               </IfController>
               <hashTree>
-                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="260 /spaces/${space_key}/pages/${ajs-content-id}/${page_title}" enabled="true">
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="265 /spaces/${space_key}/pages/${ajs-content-id}/${page_title}">
                   <stringProp name="HTTPSampler.path">${application.postfix}/spaces/${space_key}/pages/${ajs-content-id}/${page_title}</stringProp>
                   <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                   <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -2429,7 +2429,7 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                   <hashTree/>
                 </hashTree>
               </hashTree>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="270 rest/inlinecomments/1.0/comments" enabled="true">
+              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="270 rest/inlinecomments/1.0/comments">
                 <stringProp name="HTTPSampler.path">${application.postfix}/rest/inlinecomments/1.0/comments</stringProp>
                 <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                 <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -2849,14 +2849,14 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                 </JSR223PreProcessor>
                 <hashTree/>
               </hashTree>
-              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901">
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901" enabled="true">
                 <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &lt; 901)}</stringProp>
                 <boolProp name="IfController.evaluateAll">false</boolProp>
                 <boolProp name="IfController.useExpression">true</boolProp>
               </IfController>
               <hashTree>
                 <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="340 display/${space_key}/${page_title}">
-                  <stringProp name="HTTPSampler.path">${application.postfix}/sdisplay/${space_key}/${page_title}</stringProp>
+                  <stringProp name="HTTPSampler.path">${application.postfix}/display/${space_key}/${page_title}</stringProp>
                   <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                   <stringProp name="HTTPSampler.method">GET</stringProp>
                   <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
@@ -2881,13 +2881,13 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                   <hashTree/>
                 </hashTree>
               </hashTree>
-              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &gt;= 901">
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &gt;= 901" enabled="true">
                 <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &gt;= 901)}</stringProp>
                 <boolProp name="IfController.evaluateAll">false</boolProp>
                 <boolProp name="IfController.useExpression">true</boolProp>
               </IfController>
               <hashTree>
-                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="340 spaces/${space_key}/pages/${ajs-content-id}/${page_title}">
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="345 spaces/${space_key}/pages/${ajs-content-id}/${page_title}">
                   <stringProp name="HTTPSampler.path">${application.postfix}/spaces/${space_key}/pages/${ajs-content-id}/${page_title}</stringProp>
                   <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                   <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -4936,7 +4936,7 @@ if ( sleep_time &gt; 0 ) {
               </JSR223PreProcessor>
               <hashTree/>
             </hashTree>
-            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="check confluence version">
+            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="check confluence version" enabled="true">
               <stringProp name="TestPlan.comments">Run test only if confluence version is &gt;= 8.4.0</stringProp>
               <stringProp name="IfController.condition">${__groovy(vars.get(&quot;confluence-version-number&quot;).toInteger() &gt;= 804)}</stringProp>
               <boolProp name="IfController.evaluateAll">false</boolProp>

--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -334,7 +334,11 @@
               <stringProp name="filename"></stringProp>
               <stringProp name="cacheKey">true</stringProp>
               <stringProp name="script">log.info(&quot;Logged in user - thread number: ${__threadNum}&quot;)
-log.info(&quot;Confluence version: ${confluence-version}&quot;)</stringProp>
+log.info(&quot;Confluence version: ${confluence-version}&quot;)
+String confluenceVersion = vars.get(&apos;confluence-version&apos;);
+String[] versionNumbers = confluenceVersion.split(&apos;[.]&apos;)
+vars.put(&quot;confluence-version-number&quot;, &quot;&quot; + (versionNumbers[0].toInteger() * 100 + versionNumbers[1].toInteger()))
+</stringProp>
             </JSR223PostProcessor>
             <hashTree/>
           </hashTree>
@@ -459,6 +463,13 @@ log.info(&quot;Confluence version: ${confluence-version}&quot;)</stringProp>
                       <stringProp name="Argument.value">${page_id}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                    </elementProp>
+                    <elementProp name="noRedirect" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">true</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">noRedirect</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
@@ -791,7 +802,7 @@ log.info(&quot;Confluence version: ${confluence-version}&quot;)</stringProp>
                     <elementProp name="atl_after_login_redirect" elementType="HTTPArgument">
                       <boolProp name="HTTPArgument.always_encode">true</boolProp>
                       <stringProp name="Argument.name">atl_after_login_redirect</stringProp>
-                      <stringProp name="Argument.value">/pages/viewpage.action</stringProp>
+                      <stringProp name="Argument.value">/pages/viewpage.action?pageId=${page_id}&amp;noRedirect=true</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
                     </elementProp>
@@ -1084,6 +1095,13 @@ if ( sleep_time &gt; 0 ) {
                       <stringProp name="Argument.value">${blog_id}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                    </elementProp>
+                    <elementProp name="noRedirect" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">true</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">noRedirect</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
@@ -2347,30 +2365,69 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                 </JSR223PreProcessor>
                 <hashTree/>
               </hashTree>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="260 display/${space_key}/${page_title}" enabled="true">
-                <stringProp name="HTTPSampler.path">${application.postfix}/display/${space_key}/${page_title}</stringProp>
-                <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-                <stringProp name="HTTPSampler.method">GET</stringProp>
-                <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-                <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-                <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
-                  <collectionProp name="Arguments.arguments"/>
-                </elementProp>
-              </HTTPSamplerProxy>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901">
+                <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &lt; 901)}</stringProp>
+                <boolProp name="IfController.evaluateAll">false</boolProp>
+                <boolProp name="IfController.useExpression">true</boolProp>
+              </IfController>
               <hashTree>
-                <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header manager" enabled="true">
-                  <collectionProp name="HeaderManager.headers">
-                    <elementProp name="Upgrade-Insecure-Requests" elementType="Header">
-                      <stringProp name="Header.name">Upgrade-Insecure-Requests</stringProp>
-                      <stringProp name="Header.value">1</stringProp>
-                    </elementProp>
-                    <elementProp name="Accept" elementType="Header">
-                      <stringProp name="Header.name">Accept</stringProp>
-                      <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9</stringProp>
-                    </elementProp>
-                  </collectionProp>
-                </HeaderManager>
-                <hashTree/>
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="260 /display/${space_key}/${page_title}" enabled="true">
+                  <stringProp name="HTTPSampler.path">${application.postfix}/display/${space_key}/pages/${page_title}</stringProp>
+                  <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+                  <stringProp name="HTTPSampler.method">GET</stringProp>
+                  <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                  <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+                  <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+                    <collectionProp name="Arguments.arguments"/>
+                  </elementProp>
+                </HTTPSamplerProxy>
+                <hashTree>
+                  <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header manager" enabled="true">
+                    <collectionProp name="HeaderManager.headers">
+                      <elementProp name="Upgrade-Insecure-Requests" elementType="Header">
+                        <stringProp name="Header.name">Upgrade-Insecure-Requests</stringProp>
+                        <stringProp name="Header.value">1</stringProp>
+                      </elementProp>
+                      <elementProp name="Accept" elementType="Header">
+                        <stringProp name="Header.name">Accept</stringProp>
+                        <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9</stringProp>
+                      </elementProp>
+                    </collectionProp>
+                  </HeaderManager>
+                  <hashTree/>
+                </hashTree>
+              </hashTree>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &gt;= 901" enabled="true">
+                <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &gt;= 901)}</stringProp>
+                <boolProp name="IfController.evaluateAll">false</boolProp>
+                <boolProp name="IfController.useExpression">true</boolProp>
+              </IfController>
+              <hashTree>
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="260 /spaces/${space_key}/pages/${ajs-content-id}/${page_title}" enabled="true">
+                  <stringProp name="HTTPSampler.path">${application.postfix}/spaces/${space_key}/pages/${ajs-content-id}/${page_title}</stringProp>
+                  <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+                  <stringProp name="HTTPSampler.method">GET</stringProp>
+                  <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                  <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+                  <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+                    <collectionProp name="Arguments.arguments"/>
+                  </elementProp>
+                </HTTPSamplerProxy>
+                <hashTree>
+                  <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header manager" enabled="true">
+                    <collectionProp name="HeaderManager.headers">
+                      <elementProp name="Upgrade-Insecure-Requests" elementType="Header">
+                        <stringProp name="Header.name">Upgrade-Insecure-Requests</stringProp>
+                        <stringProp name="Header.value">1</stringProp>
+                      </elementProp>
+                      <elementProp name="Accept" elementType="Header">
+                        <stringProp name="Header.name">Accept</stringProp>
+                        <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9</stringProp>
+                      </elementProp>
+                    </collectionProp>
+                  </HeaderManager>
+                  <hashTree/>
+                </hashTree>
               </hashTree>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="270 rest/inlinecomments/1.0/comments" enabled="true">
                 <stringProp name="HTTPSampler.path">${application.postfix}/rest/inlinecomments/1.0/comments</stringProp>
@@ -2792,30 +2849,69 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                 </JSR223PreProcessor>
                 <hashTree/>
               </hashTree>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="340 display/${space_key}/${page_title}" enabled="true">
-                <stringProp name="HTTPSampler.path">${application.postfix}/display/${space_key}/${page_title}</stringProp>
-                <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-                <stringProp name="HTTPSampler.method">GET</stringProp>
-                <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-                <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-                <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
-                  <collectionProp name="Arguments.arguments"/>
-                </elementProp>
-              </HTTPSamplerProxy>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901">
+                <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &lt; 901)}</stringProp>
+                <boolProp name="IfController.evaluateAll">false</boolProp>
+                <boolProp name="IfController.useExpression">true</boolProp>
+              </IfController>
               <hashTree>
-                <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header manager" enabled="true">
-                  <collectionProp name="HeaderManager.headers">
-                    <elementProp name="Upgrade-Insecure-Requests" elementType="Header">
-                      <stringProp name="Header.name">Upgrade-Insecure-Requests</stringProp>
-                      <stringProp name="Header.value">1</stringProp>
-                    </elementProp>
-                    <elementProp name="Accept" elementType="Header">
-                      <stringProp name="Header.name">Accept</stringProp>
-                      <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9</stringProp>
-                    </elementProp>
-                  </collectionProp>
-                </HeaderManager>
-                <hashTree/>
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="340 display/${space_key}/${page_title}">
+                  <stringProp name="HTTPSampler.path">${application.postfix}/sdisplay/${space_key}/${page_title}</stringProp>
+                  <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+                  <stringProp name="HTTPSampler.method">GET</stringProp>
+                  <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                  <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+                  <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+                    <collectionProp name="Arguments.arguments"/>
+                  </elementProp>
+                </HTTPSamplerProxy>
+                <hashTree>
+                  <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header manager" enabled="true">
+                    <collectionProp name="HeaderManager.headers">
+                      <elementProp name="Upgrade-Insecure-Requests" elementType="Header">
+                        <stringProp name="Header.name">Upgrade-Insecure-Requests</stringProp>
+                        <stringProp name="Header.value">1</stringProp>
+                      </elementProp>
+                      <elementProp name="Accept" elementType="Header">
+                        <stringProp name="Header.name">Accept</stringProp>
+                        <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9</stringProp>
+                      </elementProp>
+                    </collectionProp>
+                  </HeaderManager>
+                  <hashTree/>
+                </hashTree>
+              </hashTree>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &gt;= 901">
+                <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &gt;= 901)}</stringProp>
+                <boolProp name="IfController.evaluateAll">false</boolProp>
+                <boolProp name="IfController.useExpression">true</boolProp>
+              </IfController>
+              <hashTree>
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="340 spaces/${space_key}/pages/${ajs-content-id}/${page_title}">
+                  <stringProp name="HTTPSampler.path">${application.postfix}/spaces/${space_key}/pages/${ajs-content-id}/${page_title}</stringProp>
+                  <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+                  <stringProp name="HTTPSampler.method">GET</stringProp>
+                  <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                  <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+                  <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+                    <collectionProp name="Arguments.arguments"/>
+                  </elementProp>
+                </HTTPSamplerProxy>
+                <hashTree>
+                  <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header manager" enabled="true">
+                    <collectionProp name="HeaderManager.headers">
+                      <elementProp name="Upgrade-Insecure-Requests" elementType="Header">
+                        <stringProp name="Header.name">Upgrade-Insecure-Requests</stringProp>
+                        <stringProp name="Header.value">1</stringProp>
+                      </elementProp>
+                      <elementProp name="Accept" elementType="Header">
+                        <stringProp name="Header.name">Accept</stringProp>
+                        <stringProp name="Header.value">text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9</stringProp>
+                      </elementProp>
+                    </collectionProp>
+                  </HeaderManager>
+                  <hashTree/>
+                </hashTree>
               </hashTree>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="350 rest/inlinecomments/1.0/comments" enabled="true">
                 <stringProp name="HTTPSampler.path">${application.postfix}/rest/inlinecomments/1.0/comments</stringProp>
@@ -3123,6 +3219,13 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                       <stringProp name="Argument.value">${ajs-content-id}</stringProp>
                       <stringProp name="Argument.metadata">=</stringProp>
                       <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                    </elementProp>
+                    <elementProp name="noRedirect" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">true</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                      <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                      <stringProp name="Argument.name">noRedirect</stringProp>
                     </elementProp>
                   </collectionProp>
                 </elementProp>
@@ -4833,9 +4936,9 @@ if ( sleep_time &gt; 0 ) {
               </JSR223PreProcessor>
               <hashTree/>
             </hashTree>
-            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="check confluence version" enabled="true">
+            <IfController guiclass="IfControllerPanel" testclass="IfController" testname="check confluence version">
               <stringProp name="TestPlan.comments">Run test only if confluence version is &gt;= 8.4.0</stringProp>
-              <stringProp name="IfController.condition">${__groovy(vars.get(&quot;confluence-version&quot;) &gt;= &quot;8.4.0&quot;)}</stringProp>
+              <stringProp name="IfController.condition">${__groovy(vars.get(&quot;confluence-version-number&quot;).toInteger() &gt;= 804)}</stringProp>
               <boolProp name="IfController.evaluateAll">false</boolProp>
               <boolProp name="IfController.useExpression">true</boolProp>
             </IfController>

--- a/app/jmeter/confluence.jmx
+++ b/app/jmeter/confluence.jmx
@@ -67,7 +67,7 @@
         </collectionProp>
       </HeaderManager>
       <hashTree/>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Confluence">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Confluence" enabled="true">
         <intProp name="ThreadGroup.num_threads">1</intProp>
         <intProp name="ThreadGroup.ramp_time">0</intProp>
         <longProp name="ThreadGroup.duration">3600</longProp>
@@ -2365,13 +2365,13 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                 </JSR223PreProcessor>
                 <hashTree/>
               </hashTree>
-              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901" enabled="true">
-                <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &lt; 901)}</stringProp>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901">
+                <stringProp name="IfController.condition">${__groovy(vars.get(&quot;confluence-version-number&quot;).toInteger() &lt; 901)}</stringProp>
                 <boolProp name="IfController.evaluateAll">false</boolProp>
                 <boolProp name="IfController.useExpression">true</boolProp>
               </IfController>
               <hashTree>
-                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="260 /display/${space_key}/${page_title}">
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="260 /display/${space_key}/${page_title}" enabled="true">
                   <stringProp name="HTTPSampler.path">${application.postfix}/display/${space_key}/${page_title}</stringProp>
                   <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                   <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -2397,13 +2397,13 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                   <hashTree/>
                 </hashTree>
               </hashTree>
-              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &gt;= 901" enabled="true">
-                <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &gt;= 901)}</stringProp>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &gt;= 901">
+                <stringProp name="IfController.condition">${__groovy(vars.get(&quot;confluence-version-number&quot;).toInteger() &gt;= 901)}</stringProp>
                 <boolProp name="IfController.evaluateAll">false</boolProp>
                 <boolProp name="IfController.useExpression">true</boolProp>
               </IfController>
               <hashTree>
-                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="265 /spaces/${space_key}/pages/${ajs-content-id}/${page_title}">
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="265 /spaces/${space_key}/pages/${ajs-content-id}/${page_title}" enabled="true">
                   <stringProp name="HTTPSampler.path">${application.postfix}/spaces/${space_key}/pages/${ajs-content-id}/${page_title}</stringProp>
                   <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                   <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -2429,7 +2429,7 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                   <hashTree/>
                 </hashTree>
               </hashTree>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="270 rest/inlinecomments/1.0/comments">
+              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="270 rest/inlinecomments/1.0/comments" enabled="true">
                 <stringProp name="HTTPSampler.path">${application.postfix}/rest/inlinecomments/1.0/comments</stringProp>
                 <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                 <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -2754,7 +2754,7 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                 </HeaderManager>
                 <hashTree/>
               </hashTree>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="320 rest/api/content/${ajs-content-id}" enabled="true">
+              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="320 rest/api/content/${ajs-content-id}">
                 <stringProp name="HTTPSampler.path">${application.postfix}/rest/api/content/${ajs-content-id}</stringProp>
                 <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                 <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -2795,7 +2795,7 @@ vars.put(&quot;page_title&quot;, &quot;jmeter_create_and_edit_page:create_page -
                 <hashTree/>
               </hashTree>
             </hashTree>
-            <TransactionController guiclass="TransactionControllerGui" testclass="TransactionController" testname="jmeter_create_and_edit_page:edit_page" enabled="true">
+            <TransactionController guiclass="TransactionControllerGui" testclass="TransactionController" testname="jmeter_create_and_edit_page:edit_page">
               <boolProp name="TransactionController.parent">true</boolProp>
               <boolProp name="TransactionController.includeTimers">false</boolProp>
             </TransactionController>
@@ -2849,13 +2849,13 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                 </JSR223PreProcessor>
                 <hashTree/>
               </hashTree>
-              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901" enabled="true">
-                <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &lt; 901)}</stringProp>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &lt; 901">
+                <stringProp name="IfController.condition">${__groovy(vars.get(&quot;confluence-version-number&quot;).toInteger() &lt; 901)}</stringProp>
                 <boolProp name="IfController.evaluateAll">false</boolProp>
                 <boolProp name="IfController.useExpression">true</boolProp>
               </IfController>
               <hashTree>
-                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="340 display/${space_key}/${page_title}">
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="340 display/${space_key}/${page_title}" enabled="true">
                   <stringProp name="HTTPSampler.path">${application.postfix}/display/${space_key}/${page_title}</stringProp>
                   <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                   <stringProp name="HTTPSampler.method">GET</stringProp>
@@ -2881,13 +2881,13 @@ vars.put(&quot;page_text&quot;, &quot;jmeter_create_and_edit_page:edit_page - &q
                   <hashTree/>
                 </hashTree>
               </hashTree>
-              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &gt;= 901" enabled="true">
-                <stringProp name="IfController.condition">${__groovy(vars.get(&apos;confluence-version-number&apos;).toInteger() &gt;= 901)}</stringProp>
+              <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If confluence-version-number &gt;= 901">
+                <stringProp name="IfController.condition">${__groovy(vars.get(&quot;confluence-version-number&quot;).toInteger() &gt;= 901)}</stringProp>
                 <boolProp name="IfController.evaluateAll">false</boolProp>
                 <boolProp name="IfController.useExpression">true</boolProp>
               </IfController>
               <hashTree>
-                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="345 spaces/${space_key}/pages/${ajs-content-id}/${page_title}">
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="345 spaces/${space_key}/pages/${ajs-content-id}/${page_title}" enabled="true">
                   <stringProp name="HTTPSampler.path">${application.postfix}/spaces/${space_key}/pages/${ajs-content-id}/${page_title}</stringProp>
                   <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                   <stringProp name="HTTPSampler.method">GET</stringProp>


### PR DESCRIPTION
When a page is visited via the legacy /display path or viewpage.action without the noRedirect query parameter, it will automatically redirect to a new URL in the form /spaces/<space-key>/pages/<page-id>/<page-title-slug>
In this PR, we add the noRedirect query parameter to the viewpage.action URL or change the /display path to the new format.