### PR TITLE
bhyde/revert bzt bump due to yaml error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN if [ "$CHROME_VERSION" = "latest" ]; then wget -O google-chrome.deb $CHROME_
   && rm -rf ./google-chrome.deb
 
 COPY requirements.txt /tmp/requirements.txt
-#TODO Remove --no-deps after Taurus will install the latest setuptools https://raw.githubusercontent.com/Blazemeter/taurus/refs/heads/master/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt --no-deps
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 RUN if [ "$INCLUDE_BZT" = "true" ]; then \
       wget https://blazemeter-tools.s3.us-east-2.amazonaws.com/bzt.tar.gz -O /tmp/bzt.tar.gz && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ selenium==4.31.0
 filelock==3.18.0
 packaging==24.2
 prettytable==3.16.0
-bzt==1.16.42
+bzt==1.16.32        # bzt 1.16.34 has pinned setuptools==65.5.0, which does not have distutils
 boto3==1.37.30
 retry==0.9.2


### PR DESCRIPTION
error	31-May-2025 03:02:52	dev: Pulling from atlassian/dcapt
...
error	31-May-2025 03:03:01	a6f1fe26bb27: Pull complete
error	31-May-2025 03:03:03	a75d6df50560: Pull complete
error	31-May-2025 03:03:03	5cd2014f2182: Pull complete
error	31-May-2025 03:03:03	b7df2643f337: Pull complete
error	31-May-2025 03:03:03	Digest: sha256:367ead4a622c28bad213c943f75d8efc375a6fdfd89a6b2f33984f0287ef83fe
error	31-May-2025 03:03:03	Status: Downloaded newer image for atlassian/dcapt:dev
error	31-May-2025 03:03:03	Traceback (most recent call last):
error	31-May-2025 03:03:03	  File "/dcapt/dcapt-tooling/ci/python_scripts/edit_yml.py", line 1, in <module>
error	31-May-2025 03:03:03	    from utils import write_yml_file, read_yml_file
error	31-May-2025 03:03:03	  File "/dcapt/dcapt-tooling/ci/python_scripts/utils.py", line 2, in <module>
error	31-May-2025 03:03:03	    import yaml
error	31-May-2025 03:03:03	ModuleNotFoundError: No module named 'yaml'
build	31-May-2025 03:03:03	Edited environment file dcapt-tooling/perft/ci/confluence-dcapt-env.yaml: