### PR TITLE
Fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ boto3==1.42.33
 retry==0.9.2
 apiritif==1.1.3
 pytest-xdist==3.8.0
+chardet>=5.0,<6.0
+urllib3==2.5.0


### PR DESCRIPTION
Chardet 7.0.1 removed the UniversalDetector class (it was replaced with CharsetMatches), but apiritif 1.1.3 is trying to import it.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

