### PR TITLE
Release/8.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ ENV CHROME_LATEST_URL="https://dl.google.com/linux/direct/google-chrome-stable_c
 ENV CHROME_VERSION_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb"
 
 RUN apt-get -y update \
-  && $APT_INSTALL vim git openssh-server wget \
+  && apt-get -y upgrade \
+  && $APT_INSTALL git openssh-server wget \
   && python -m pip install --upgrade pip \
   && apt-get clean
 

--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -20,7 +20,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.6.3
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     # Action percentage for JMeter load executor
     view_all_builds: 15

--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -126,7 +126,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -126,7 +126,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -126,7 +126,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "148.0.7778.178" # Supports Chrome version 148. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -126,7 +126,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.155" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bamboo.yml
+++ b/app/bamboo.yml
@@ -126,7 +126,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -20,7 +20,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.6.3
     LANGUAGE: en_US.utf8
-    allow_analytics: No                # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes                # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     local_chrome_binary_path:          # e.g. /usr/bin/google-chrome-stable. Leave it blank to use default Chrome binary path.
     chrome_options:                # Optional Chrome browser options for Selenium. Avoids manual edits to Python files in CI/CD.

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -92,7 +92,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -92,7 +92,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "148.0.7778.178" # Supports Chrome version 148. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -92,7 +92,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -92,7 +92,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/bitbucket.yml
+++ b/app/bitbucket.yml
@@ -92,7 +92,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.155" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -20,7 +20,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.6.3
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     extended_metrics: False
     # Action percentage for JMeter and Locust load executors

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -119,7 +119,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.155" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -119,7 +119,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -119,7 +119,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "148.0.7778.178" # Supports Chrome version 148. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -119,7 +119,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/confluence.yml
+++ b/app/confluence.yml
@@ -119,7 +119,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/crowd.yml
+++ b/app/crowd.yml
@@ -32,7 +32,7 @@ settings:
 
     JMETER_VERSION: 5.6.3
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
 services:
   - module: shellexec

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -20,7 +20,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.6.3
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     # Action percentage for Jmeter and Locust load executors
     create_issue: 4

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -120,7 +120,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "148.0.7778.178" # Supports Chrome version 148. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -120,7 +120,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.155" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -120,7 +120,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -120,7 +120,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/jira.yml
+++ b/app/jira.yml
@@ -120,7 +120,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
 - data-source: sample-labels
   module: junit-xml

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -23,7 +23,7 @@ settings:
     WEBDRIVER_VISIBLE: False
     JMETER_VERSION: 5.6.3
     LANGUAGE: en_US.utf8
-    allow_analytics: No               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
+    allow_analytics: Yes               # Allow sending basic run analytics to Atlassian. These analytics help us to understand how the tool is being used and help us to continue to invest in this tooling. For more details please see our README.
     environment_compliance_check: True # Pre-test environment compliance validation. Set to "False" to skip it.
     # Action percentage for Jmeter and Locust load executors
     agent_browse_projects: 10

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -171,7 +171,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
   - data-source: sample-labels
     module: junit-xml

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -171,7 +171,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
   - data-source: sample-labels
     module: junit-xml

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -171,7 +171,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.54" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.55" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
   - data-source: sample-labels
     module: junit-xml

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -171,7 +171,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "149.0.7827.115" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.155" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
   - data-source: sample-labels
     module: junit-xml

--- a/app/jsm.yml
+++ b/app/jsm.yml
@@ -171,7 +171,7 @@ modules:
       httpsampler.ignore_failed_embedded_resources: "true"
   selenium:
     chromedriver:
-      version: "148.0.7778.178" # Supports Chrome version 148. You can refer to https://googlechromelabs.github.io/chrome-for-testing
+      version: "149.0.7827.22" # Supports Chrome version 149. You can refer to https://googlechromelabs.github.io/chrome-for-testing
 reporting:
   - data-source: sample-labels
     module: junit-xml

--- a/app/util/conf.py
+++ b/app/util/conf.py
@@ -2,8 +2,8 @@ import yaml
 
 from util.project_paths import JIRA_YML, CONFLUENCE_YML, BITBUCKET_YML, JSM_YML, CROWD_YML, BAMBOO_YML
 
-TOOLKIT_VERSION = '8.11.0'
-UNSUPPORTED_VERSION = '8.8.0'
+TOOLKIT_VERSION = '8.10.4'
+UNSUPPORTED_VERSION = '8.7.0'
 
 
 def read_yml_file(file):

--- a/app/util/k8s/README.MD
+++ b/app/util/k8s/README.MD
@@ -32,7 +32,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.9.10 ./install.sh -c conf.tfvars
+-it atlassianlabs/terraform:terraform:2.9.23 ./install.sh -c conf.tfvars
 ```
 ### Terminate development environment
 Note: install and uninstall commands have to use the same `atlassianlabs/terraform:TAG` image tag.
@@ -44,7 +44,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.9.10 ./uninstall.sh -c conf.tfvars
+-it atlassianlabs/terraform:2.9.23 ./uninstall.sh -c conf.tfvars
 ```
 
 # Enterprise-scale environment
@@ -61,7 +61,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.9.10 ./install.sh -c conf.tfvars
+-it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
 ```
 ### Terminate enterprise-scale environment
 Note: install and uninstall commands have to use the same `atlassianlabs/terraform:TAG` image tag.
@@ -73,7 +73,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.9.10 ./uninstall.sh -c conf.tfvars
+-it atlassianlabs/terraform:2.9.23 ./uninstall.sh -c conf.tfvars
 ```
 
 # Collect detailed k8s logs
@@ -93,7 +93,7 @@ export REGION=us-east-2
 docker run --pull=always --env-file aws_envs \
 -v "/$PWD/k8s_logs:/data-center-terraform/k8s_logs" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:2.9.10 ./scripts/collect_k8s_logs.sh atlas-$ENVIRONMENT_NAME-cluster $REGION k8s_logs
+-it atlassianlabs/terraform:2.9.23 ./scripts/collect_k8s_logs.sh atlas-$ENVIRONMENT_NAME-cluster $REGION k8s_logs
 ```
 
 # Force terminate cluster
@@ -126,7 +126,7 @@ atlassian/dcapt terminate_cluster.py --cluster_name atlas-$ENVIRONMENT_NAME-clus
     docker run --pull=always --env-file aws_envs \
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -e REGION=$REGION \
-    -it atlassianlabs/terraform:2.9.10 bash 
+    -it atlassianlabs/terraform:2.9.23 bash 
     ```
 
 5. Connect to the product pod. Example below for jira pod with number 0. For other product or pod number change `PRODUCT_POD` accordingly.
@@ -150,7 +150,7 @@ atlassian/dcapt terminate_cluster.py --cluster_name atlas-$ENVIRONMENT_NAME-clus
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -e REGION=$REGION \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
-    -it atlassianlabs/terraform:2.9.10 bash 
+    -it atlassianlabs/terraform:2.9.23 bash 
     ```
 5. Copy code base and connect to the execution environment pod:
     ``` bash
@@ -178,7 +178,7 @@ atlassian/dcapt terminate_cluster.py --cluster_name atlas-$ENVIRONMENT_NAME-clus
     -e REGION=$REGION \
     -e PRODUCT=$PRODUCT \
     -v "/$PWD/script-runner.yml:/data-center-terraform/script-runner.yml" \
-    -it atlassianlabs/terraform:2.9.10 bash 
+    -it atlassianlabs/terraform:2.9.23 bash 
     ```
 5. Run following commands one by one inside docker container:
     ``` bash
@@ -206,7 +206,7 @@ To enable detailed CPU/Memory monitoring and Grafana dashboards for visualisatio
     docker run --pull=always --env-file aws_envs \
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -e REGION=$REGION \
-    -it atlassianlabs/terraform:2.9.10 bash 
+    -it atlassianlabs/terraform:2.9.23 bash 
     ```
     ``` bash
     aws eks update-kubeconfig --name atlas-$ENVIRONMENT_NAME-cluster --region $REGION
@@ -242,7 +242,7 @@ Note: this option is **not** suitable for full-scale performance runs as local n
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.10 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jira.yml
     ```
 
 # Retry to copy run results from the execution environment pod to local
@@ -259,7 +259,7 @@ Note: this option is **not** suitable for full-scale performance runs as local n
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/copy_run_results.sh:/data-center-terraform/copy_run_results.sh" \
-    -it atlassianlabs/terraform:2.9.10 bash copy_run_results.sh
+    -it atlassianlabs/terraform:2.9.23 bash copy_run_results.sh
     ```
 
 # Debug AWS required policies
@@ -268,7 +268,7 @@ Note: this option is **not** suitable for full-scale performance runs as local n
 3. Start and ssh to `atlassianlabs/terraform` docker container:
     ``` bash
     docker run --pull=always --env-file aws_envs \
-    -it atlassianlabs/terraform:2.9.10 bash 
+    -it atlassianlabs/terraform:2.9.23 bash 
     ```
 4. Make sure you have IAM policies with names `policy1`, `policy2`, created from [policy1.json](https://github.com/atlassian-labs/data-center-terraform/blob/main/permissions/policy1.json) and [policy2.json](https://github.com/atlassian-labs/data-center-terraform/blob/main/permissions/policy2.json).
 5. Run following commands one by one inside docker container to get effective policies permissions:

--- a/app/util/k8s/README.MD
+++ b/app/util/k8s/README.MD
@@ -32,7 +32,7 @@ docker run --pull=always --env-file aws_envs \
 -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
 -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
 -v "/$PWD/logs:/data-center-terraform/logs" \
--it atlassianlabs/terraform:terraform:2.9.23 ./install.sh -c conf.tfvars
+-it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
 ```
 ### Terminate development environment
 Note: install and uninstall commands have to use the same `atlassianlabs/terraform:TAG` image tag.

--- a/app/util/k8s/dcapt-small.tfvars
+++ b/app/util/k8s/dcapt-small.tfvars
@@ -72,6 +72,12 @@ max_cluster_capacity = 2
 # This can be used in case you hit the limit which can happen if 30+ whitelist_cidrs are provided.
 #enable_https_ingress = false
 
+# Use Gateway API (Envoy Gateway) instead of NGINX Ingress controller.
+# When set to true, Envoy Gateway is deployed as a drop-in replacement for NGINX. Only one can be active per deployment.
+# If `domain` is set, HTTPS is used with TLS termination via ACM cert; otherwise the raw NLB hostname is used over HTTP.
+# For Bitbucket, SSH on port 7999 is handled natively via TCPRoute (no manual ELB listener modification needed).
+use_gateway_api = "true"
+
 ################################################################################
 # Jira/JSM Settings
 ################################################################################

--- a/app/util/k8s/dcapt-small.tfvars
+++ b/app/util/k8s/dcapt-small.tfvars
@@ -76,7 +76,7 @@ max_cluster_capacity = 2
 # When set to true, Envoy Gateway is deployed as a drop-in replacement for NGINX. Only one can be active per deployment.
 # If `domain` is set, HTTPS is used with TLS termination via ACM cert; otherwise the raw NLB hostname is used over HTTP.
 # For Bitbucket, SSH on port 7999 is handled natively via TCPRoute (no manual ELB listener modification needed).
-use_gateway_api = "true"
+# use_gateway_api = "true"
 
 ################################################################################
 # Jira/JSM Settings

--- a/app/util/k8s/dcapt.tfvars
+++ b/app/util/k8s/dcapt.tfvars
@@ -85,7 +85,7 @@ max_cluster_capacity = 6
 # When set to true, Envoy Gateway is deployed as a drop-in replacement for NGINX. Only one can be active per deployment.
 # If `domain` is set, HTTPS is used with TLS termination via ACM cert; otherwise the raw NLB hostname is used over HTTP.
 # For Bitbucket, SSH on port 7999 is handled natively via TCPRoute (no manual ELB listener modification needed).
-use_gateway_api = "true"
+# use_gateway_api = "true"
 
 ################################################################################
 # Execution Environment Settings

--- a/app/util/k8s/dcapt.tfvars
+++ b/app/util/k8s/dcapt.tfvars
@@ -81,6 +81,12 @@ max_cluster_capacity = 6
 # This can be used in case you hit the limit which can happen if 30+ whitelist_cidrs are provided.
 #enable_https_ingress = false
 
+# Use Gateway API (Envoy Gateway) instead of NGINX Ingress controller.
+# When set to true, Envoy Gateway is deployed as a drop-in replacement for NGINX. Only one can be active per deployment.
+# If `domain` is set, HTTPS is used with TLS termination via ACM cert; otherwise the raw NLB hostname is used over HTTP.
+# For Bitbucket, SSH on port 7999 is handled natively via TCPRoute (no manual ELB listener modification needed).
+use_gateway_api = "true"
+
 ################################################################################
 # Execution Environment Settings
 ################################################################################

--- a/docs/dc-apps-performance-toolkit-user-guide-bamboo.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-bamboo.md
@@ -101,7 +101,7 @@ specifically for performance testing during the DC app review process.
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 7. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/bamboo`.
 8. Wait for all remote agents to be started and connected. It can take up to 10 minutes. Agents can be checked in `Settings` > `Agents`.
@@ -302,7 +302,7 @@ To receive performance baseline results **without** an app installed and **witho
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh bamboo.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh bamboo.yml
     ```
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/bamboo/YY-MM-DD-hh-mm-ss` folder:
     - `results_summary.log`: detailed run summary
@@ -333,7 +333,7 @@ To receive performance results with an app installed (still use master branch):
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh bamboo.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh bamboo.yml
     ```
 
 {{% note %}}
@@ -367,7 +367,7 @@ To receive results for Bamboo DC **with app** and **with app-specific actions**:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh bamboo.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh bamboo.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-bamboo.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-bamboo.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2026-05-19"
+date: "2026-06-17"
 ---
 # Data Center App Performance Toolkit User Guide For Bamboo
 

--- a/docs/dc-apps-performance-toolkit-user-guide-bitbucket.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-bitbucket.md
@@ -114,7 +114,7 @@ Below process describes how to install low-tier Bitbucket DC with "small" datase
    -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/bitbucket`.
 
@@ -317,7 +317,7 @@ Below process describes how to install enterprise-scale Bitbucket DC with "large
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/bitbucket`.
 
@@ -392,7 +392,7 @@ To receive performance baseline results **without** an app installed:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh bitbucket.yml
     ```
 
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/bitbucket/YY-MM-DD-hh-mm-ss` folder:
@@ -423,7 +423,7 @@ To receive performance results with an app installed (still use master branch):
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh bitbucket.yml
     ```
 
 {{% note %}}
@@ -473,7 +473,7 @@ To receive scalability benchmark results for one-node Bitbucket DC **with** app-
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh bitbucket.yml
     ```
    
 {{% note %}}
@@ -498,7 +498,7 @@ To receive scalability benchmark results for two-node Bitbucket DC **with** app-
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 1. Navigate to `dc-app-performance-toolkit` folder and start tests execution:
     ``` bash
@@ -511,7 +511,7 @@ To receive scalability benchmark results for two-node Bitbucket DC **with** app-
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh bitbucket.yml
     ```
 
 {{% note %}}
@@ -540,7 +540,7 @@ To receive scalability benchmark results for four-node Bitbucket DC with app-spe
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh bitbucket.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh bitbucket.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-bitbucket.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-bitbucket.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2026-05-19"
+date: "2026-06-17"
 ---
 # Data Center App Performance Toolkit User Guide For Bitbucket
 

--- a/docs/dc-apps-performance-toolkit-user-guide-confluence.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-confluence.md
@@ -113,7 +113,7 @@ Below process describes how to install low-tier Confluence DC with "small" datas
    -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/confluence`.
 
@@ -397,7 +397,7 @@ Below process describes how to install enterprise-scale Confluence DC with "larg
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/confluence`.
 
@@ -472,7 +472,7 @@ To receive performance baseline results **without** an app installed:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh confluence.yml
     ```
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/confluence/YY-MM-DD-hh-mm-ss` folder:
     - `results_summary.log`: detailed run summary
@@ -502,7 +502,7 @@ To receive performance results with an app installed (still use master branch):
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh confluence.yml
     ```
 
 {{% note %}}
@@ -563,7 +563,7 @@ To receive scalability benchmark results for one-node Confluence DC **with** app
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh confluence.yml
     ```
 
 {{% note %}}
@@ -588,7 +588,7 @@ To receive scalability benchmark results for two-node Confluence DC **with** app
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 1. Navigate to `dc-app-performance-toolkit` folder and start tests execution:
     ``` bash
@@ -601,7 +601,7 @@ To receive scalability benchmark results for two-node Confluence DC **with** app
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh confluence.yml
     ```
 
 {{% note %}}
@@ -630,7 +630,7 @@ To receive scalability benchmark results for four-node Confluence DC with app-sp
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh confluence.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh confluence.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-confluence.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-confluence.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2026-05-19"
+date: "2026-06-17"
 ---
 # Data Center App Performance Toolkit User Guide For Confluence
 

--- a/docs/dc-apps-performance-toolkit-user-guide-crowd.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-crowd.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2026-05-19"
+date: "2026-06-17"
 ---
 # Data Center App Performance Toolkit User Guide For Crowd
 

--- a/docs/dc-apps-performance-toolkit-user-guide-crowd.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-crowd.md
@@ -96,7 +96,7 @@ specifically for performance testing during the DC app review process.
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 7. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/crowd`.
 
@@ -207,7 +207,7 @@ To receive performance baseline results **without** an app installed and **witho
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh crowd.yml
     ```
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/crowd/YY-MM-DD-hh-mm-ss` folder:
     - `results_summary.log`: detailed run summary
@@ -236,7 +236,7 @@ To receive performance results with an app installed (still use master branch):
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh crowd.yml
     ```
 
 {{% note %}}
@@ -295,7 +295,7 @@ To receive scalability benchmark results for one-node Crowd DC **with** app-spec
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh crowd.yml
     ```
 
 {{% note %}}
@@ -319,7 +319,7 @@ To receive scalability benchmark results for two-node Crowd DC **with** app-spec
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 1. Edit **run parameters** for 2 nodes run. To do it, left uncommented only 2 nodes scenario parameters in `crowd.yml` file.
    ```
@@ -346,7 +346,7 @@ To receive scalability benchmark results for two-node Crowd DC **with** app-spec
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh crowd.yml
     ```
 
 {{% note %}}
@@ -389,7 +389,7 @@ To receive scalability benchmark results for four-node Crowd DC with app-specifi
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh crowd.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh crowd.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-jira.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-jira.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2026-05-19"
+date: "2026-06-17"
 ---
 # Data Center App Performance Toolkit User Guide For Jira
 

--- a/docs/dc-apps-performance-toolkit-user-guide-jira.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-jira.md
@@ -121,7 +121,7 @@ Below process describes how to install low-tier Jira DC with "small" dataset inc
    -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/jira`.
@@ -421,7 +421,7 @@ Below process describes how to install enterprise-scale Jira DC with "large" dat
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/jira`.
 
@@ -496,7 +496,7 @@ To receive performance baseline results **without** an app installed:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jira.yml
     ```
 1. View the results files of the run in the local `dc-app-performance-toolkit/app/results/jira/YY-MM-DD-hh-mm-ss` folder:
    - `results_summary.log`: detailed run summary
@@ -548,7 +548,7 @@ The re-index time for Jira is about ~50-70 minutes.
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jira.yml
     ```
 
 {{% note %}}
@@ -609,7 +609,7 @@ To receive scalability benchmark results for one-node Jira DC **with** app-speci
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jira.yml
     ```
 
 {{% note %}}
@@ -634,7 +634,7 @@ To receive scalability benchmark results for two-node Jira DC **with** app-speci
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 1. Navigate to `dc-app-performance-toolkit` folder and start tests execution:
     ``` bash
@@ -647,7 +647,7 @@ To receive scalability benchmark results for two-node Jira DC **with** app-speci
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jira.yml
     ```
 
 {{% note %}}
@@ -676,7 +676,7 @@ To receive scalability benchmark results for four-node Jira DC with app-specific
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jira.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jira.yml
     ```
 
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-jsm.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-jsm.md
@@ -123,7 +123,7 @@ Below process describes how to install low-tier Jira Service Management DC with 
    -v "/$PWD/dcapt-small.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/jira`.
 
@@ -457,7 +457,7 @@ Below process describes how to install enterprise-scale Jira Service Management 
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 8. Copy product URL from the console output. Product url should look like `http://a1234-54321.us-east-2.elb.amazonaws.com/jira`.
 
@@ -537,7 +537,7 @@ To receive performance baseline results **without** an app installed:
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jsm.yml
     ```
 
 1. View the following main results of the run in the `dc-app-performance-toolkit/app/results/jsm/YY-MM-DD-hh-mm-ss` folder:
@@ -592,7 +592,7 @@ Re-index information window is displayed on the **Indexing page**. If the window
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jsm.yml
     ```
 
 {{% note %}}
@@ -652,7 +652,7 @@ To receive scalability benchmark results for one-node Jira Service Management DC
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jsm.yml
     ```
 
 {{% note %}}
@@ -677,7 +677,7 @@ To receive scalability benchmark results for two-node Jira Service Management DC
    -v "/$PWD/dcapt.tfvars:/data-center-terraform/conf.tfvars" \
    -v "/$PWD/dcapt-snapshots.json:/data-center-terraform/dcapt-snapshots.json" \
    -v "/$PWD/logs:/data-center-terraform/logs" \
-   -it atlassianlabs/terraform:2.9.21 ./install.sh -c conf.tfvars
+   -it atlassianlabs/terraform:2.9.23 ./install.sh -c conf.tfvars
    ```
 1. Navigate to `dc-app-performance-toolkit` folder and start tests execution:
     ``` bash
@@ -690,7 +690,7 @@ To receive scalability benchmark results for two-node Jira Service Management DC
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jsm.yml
     ```
 
 {{% note %}}
@@ -719,7 +719,7 @@ To receive scalability benchmark results for four-node Jira Service Management D
     -e ENVIRONMENT_NAME=$ENVIRONMENT_NAME \
     -v "/$PWD:/data-center-terraform/dc-app-performance-toolkit" \
     -v "/$PWD/app/util/k8s/bzt_on_pod.sh:/data-center-terraform/bzt_on_pod.sh" \
-    -it atlassianlabs/terraform:2.9.21 bash bzt_on_pod.sh jsm.yml
+    -it atlassianlabs/terraform:2.9.23 bash bzt_on_pod.sh jsm.yml
     ```
    
 {{% note %}}

--- a/docs/dc-apps-performance-toolkit-user-guide-jsm.md
+++ b/docs/dc-apps-performance-toolkit-user-guide-jsm.md
@@ -4,7 +4,7 @@ platform: platform
 product: marketplace
 category: devguide
 subcategory: build
-date: "2026-05-19"
+date: "2026-06-17"
 ---
 # Data Center App Performance Toolkit User Guide For Jira Service Management
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ selenium==4.39.0
 filelock==3.20.3
 packaging==25.0
 prettytable==3.17.0
-bzt==1.16.49
+bzt==1.16.51
 urwid==3.0.2
 boto3==1.42.33
 retry==0.9.2
 apiritif==1.1.3
 pytest-xdist==3.8.0
 chardet>=5.0,<6.0
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
# Version 8.10.4

## Changed
- Bump Chromedriver to `149.0.7827.155`
- Bump terraform version tag fixing deployment dependencies and issues
- Dependencies version updates

## Upgrade instructions
- `git pull` from `master` branch
- activate virtual env for the toolkit (see README.md for details)
- `pip install -r requirements.txt`

## Important
Use the same `atlassianlabs/terraform` image tag to deploy, upgrade, and undeploy the environment.

